### PR TITLE
GUI rewrite: intent-first dropdowns + per-field hover tooltips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.egg-info/
+.pytest_cache/
+bar_debug_launcher_config.json
+bar_debug_launcher_script.txt

--- a/BAR_Debug_Launcher.py
+++ b/BAR_Debug_Launcher.py
@@ -36,7 +36,7 @@ from bar_launch.intents import (
 )
 
 #Try to figure out the BAR install path:
-barinstallpath = os.path.abspath(os.path.dirname(sys.argv[0])) 
+barinstallpath = os.environ.get("BAR_INSTALL_PATH") or os.path.abspath(os.path.dirname(sys.argv[0])) 
 cwd = os.getcwd()
 #This is needed for double-click launches, as then the CWD is wherever the demo file is
 os.chdir(barinstallpath)
@@ -84,7 +84,7 @@ def find_linux_launcher_binary():
 if platform.system() == 'Windows':
     engine_binary = 'spring.exe'
     prd_binary = 'pr-downloader.exe'
-    datafolder = 'data'
+    datafolder = os.environ.get("BAR_DATA_DIR", 'data')
     launcher_binary_display = launcher_binary = 'Beyond-All-Reason.exe'
     engine_download_baseurl = 'https://github.com/beyond-all-reason/spring/releases/download/spring_bar_%7BBAR105%7D{enginebaseversion}/spring_bar_.BAR105.{enginebaseversion}_windows-64-minimal-portable.7z'
     engine_download_baseurl_new = 'https://github.com/beyond-all-reason/spring/releases/download/{enginebaseversion}/spring_bar_.{releaseID}.{enginebaseversion}_windows-64-minimal-portable.7z'

--- a/BAR_Debug_Launcher.py
+++ b/BAR_Debug_Launcher.py
@@ -24,6 +24,8 @@ from parse_demo_file import Parse_demo_file
 
 from slpp import slpp
 
+from bar_launch.core import find_linux_launcher_binary as _find_linux_launcher_binary
+
 #Try to figure out the BAR install path:
 barinstallpath = os.path.abspath(os.path.dirname(sys.argv[0])) 
 cwd = os.getcwd()
@@ -65,11 +67,10 @@ def find_linux_datadir():
     return os.path.join(state_home, 'Beyond All Reason')
 
 def find_linux_launcher_binary():
-    # Searches for the newest AppImage file in the current directory
-    for file in reversed(sorted(os.listdir())):
-        if re.match(r'^beyond[-_]?all[-_]?reason.*\.appimage$', file, re.IGNORECASE):
-            return file
-    return 'Beyond-All-Reason.AppImage'  # Just something to return...
+    # Honors $BAR_APPIMAGE_PATH and --launcher-binary first; falls back to
+    # the legacy cwd scan so the standalone "drop next to the AppImage and
+    # double-click" workflow keeps working.
+    return _find_linux_launcher_binary(barinstallpath)
 
 if platform.system() == 'Windows':
     engine_binary = 'spring.exe'
@@ -205,6 +206,16 @@ def parsecache(path):
         print ("parsecache error, dont code blind!", e)
     return maps, games, menus
 
+def parsemodinfo(path):
+    try:
+        with open(path, 'r') as f:
+            contents = f.read()
+        table_str = '{' + contents.partition('{')[2].rpartition('}')[0] + '}'
+        return slpp.decode(table_str)
+    except Exception as e:
+        print(f"Error parsing {path}: {e}")
+        return None
+
 def refresh():
     global modinfos
     #global enginepaths
@@ -227,26 +238,34 @@ def refresh():
         if '$VERSION' in gamename:
             modinfos[gamename] = {'modtype': '1', 'name': gamename}
 
-    
-    # assume rapid://byar-chobby:test
-    # assume rapid://byar:test
-
-    #check menus for $VERSION's
-
-
-    '''
-    if os.path.exists(os.path.join(datafolder, 'games')):
-        gamespath = os.path.join(datafolder, 'games')
+    # Surface locally-checked-out games (e.g. via Devtools' link::create) as
+    # [LOCAL] entries so the dropdown distinguishes them from rapid:// builds.
+    gamespath = os.path.join(datafolder, 'games')
+    if os.path.exists(gamespath):
         for gamedir in os.listdir(gamespath):
-            if os.path.isdir(os.path.join(gamespath)):
-                gamepath = os.path.join(gamespath, gamedir)
-                modinfopath = os.path.join(gamepath, 'modinfo.lua')
-                if os.path.exists(modinfopath):
-                    modinfo = parsemodinfo(modinfopath)
-                    modinfos[modinfo['name'] + " " + modinfo['version']] = modinfo
+            gamepath = os.path.join(gamespath, gamedir)
+            if not os.path.isdir(gamepath):
+                continue
+            modinfopath = os.path.join(gamepath, 'modinfo.lua')
+            if not os.path.exists(modinfopath):
+                continue
+            modinfo = parsemodinfo(modinfopath)
+            if not (modinfo and 'name' in modinfo):
+                continue
+            base_name = modinfo['name']
+            version = modinfo.get('version', '')
+            if version == '$VERSION' and '$VERSION' not in base_name:
+                name = f"{base_name} $VERSION"
+            else:
+                name = base_name
+            mtype = str(modinfo.get('modtype', '1'))
+            display_name = f"[LOCAL] {gamedir}"
+            modinfos[display_name] = {'modtype': mtype, 'name': name}
+            if mtype == '5':
+                modinfos[f"[LOCAL] Spring-launcher with {gamedir}"] = {'modtype': '0', 'name': name}
+
     for k, v in modinfos.items():
         print(k, v)
-    '''
 
 refresh()
 

--- a/BAR_Debug_Launcher.py
+++ b/BAR_Debug_Launcher.py
@@ -25,7 +25,7 @@ from parse_demo_file import Parse_demo_file
 
 from slpp import slpp
 
-from bar_launch.core import Context, find_linux_launcher_binary as _find_linux_launcher_binary
+from bar_launch.core import Context, find_linux_launcher_binary as _find_linux_launcher_binary, host_cmd_prefix
 from bar_launch.engine_cmd import build_runcmd
 from bar_launch.intents import (
     BOOT_CHOICES,
@@ -453,7 +453,7 @@ def try_start_replay(replayfilepath):
     #5. start the demo 
     runcmd = f'"{os.path.join(barinstallpath, datafolder,"engine",enginedir, engine_binary)}"  --isolation --write-dir "{os.path.join(barinstallpath, datafolder)}" "{savedreplaypath}"'
     print ("Launching engine for replay with:", runcmd)
-    subprocess.Popen(shlex.split(runcmd),close_fds=True )
+    subprocess.Popen(host_cmd_prefix() + shlex.split(runcmd),close_fds=True )
     #print (demo.header)
 
 
@@ -507,6 +507,34 @@ class _Tooltip:
 
 if len(sys.argv) < 2: # no arguments passed, use GUI
     root = tk.Tk()
+    # Defer to the OS: a healthy desktop Tk already honors the fontconfig default
+    # family and the display DPI (tk scaling), so we leave those alone on KDE /
+    # GNOME / etc. But some Tk builds (notably Homebrew's on Linux) can't see the
+    # system fonts and fall back to the non-scalable X11 'fixed' bitmap -- detect
+    # that and pin to the best available scalable family so text renders & scales.
+    # BAR_TK_SCALING=<float> overrides the DPI-derived scaling for manual tuning.
+    import tkinter.font as _tkfont
+    _avail = {f.lower(): f for f in _tkfont.families(root)}
+    def _pick_family(prefs, fallback):
+        for _p in prefs:
+            if _p.lower() in _avail:
+                return _avail[_p.lower()]
+        return fallback
+    _default = _tkfont.nametofont('TkDefaultFont')
+    if _default.actual('family').lower() == 'fixed':
+        UI_SANS = _pick_family(['DejaVu Sans', 'Noto Sans', 'Liberation Sans', 'Helvetica', 'Arial'], 'Liberation Sans')
+        UI_MONO = _pick_family(['DejaVu Sans Mono', 'Liberation Mono', 'Noto Sans Mono', 'Courier New'], 'Liberation Mono')
+        for _name in _tkfont.names(root):
+            _tkfont.nametofont(_name).configure(family=(UI_MONO if _name == 'TkFixedFont' else UI_SANS))
+    else:
+        UI_SANS = _default.actual('family')
+        UI_MONO = _tkfont.nametofont('TkFixedFont').actual('family')
+    _scale_override = os.environ.get('BAR_TK_SCALING')
+    if _scale_override:
+        try:
+            root.tk.call('tk', 'scaling', float(_scale_override))
+        except (ValueError, tk.TclError):
+            pass
     # ----- Window-size floors (single edit point) -------------------------
     # Final window size is max(MIN_*, measured content size). Edit these to
     # taste -- if you want a smaller window, lower the floor. The measure
@@ -538,7 +566,7 @@ if len(sys.argv) < 2: # no arguments passed, use GUI
     style.configure('Hint.TLabel', foreground='#666')
     style.configure('Link.TLabel', foreground='#2563eb')
     style.configure('Section.TLabelframe', padding=10)
-    style.configure('Section.TLabelframe.Label', font=('TkDefaultFont', 10, 'bold'))
+    style.configure('Section.TLabelframe.Label', font=(UI_SANS, 10, 'bold'))
 
     PAD = 8
 
@@ -566,8 +594,8 @@ if len(sys.argv) < 2: # no arguments passed, use GUI
     _link = ttk.Label(header, text="GitHub ↗", style='Link.TLabel', cursor='hand2')
     _link.grid(row=0, column=1, sticky=tk.E, padx=(PAD, 0))
     _link.bind('<Button-1>', lambda e: webbrowser.open(_GH_URL))
-    _link.bind('<Enter>', lambda e: _link.configure(font=('TkDefaultFont', 9, 'underline')))
-    _link.bind('<Leave>', lambda e: _link.configure(font=('TkDefaultFont', 9)))
+    _link.bind('<Enter>', lambda e: _link.configure(font=(UI_SANS, 9, 'underline')))
+    _link.bind('<Leave>', lambda e: _link.configure(font=(UI_SANS, 9)))
 
     # ---------------------------------------------------------------------
     # Intent-first config: Engine, then (Play, Source, Boot, Map) in a
@@ -700,7 +728,7 @@ if len(sys.argv) < 2: # no arguments passed, use GUI
     # width=1 so Tk doesn't claim the default 80-column natural width as the
     # window's required width -- the LabelFrame stretches via fill=tk.X and
     # the inner Text follows. Without this the Text alone forces ~560px.
-    cmdtext = tk.Text(cmd_frame, height=4, width=1, font=("Courier", 9),
+    cmdtext = tk.Text(cmd_frame, height=4, width=1, font=(UI_MONO, 9),
                       wrap=tk.WORD, relief=tk.FLAT, borderwidth=0,
                       background="#f5f5f5")
     cmdtext.pack(fill=tk.X)
@@ -708,7 +736,7 @@ if len(sys.argv) < 2: # no arguments passed, use GUI
     # Modoptions
     mod_frame = ttk.LabelFrame(root, text='Additional modoptions', style='Section.TLabelframe')
     mod_frame.grid(row=3, column=0, sticky=tk.EW, padx=PAD, pady=PAD // 2)
-    modoptionstb = tk.Text(mod_frame, height=3, width=1, font=("Courier", 9),
+    modoptionstb = tk.Text(mod_frame, height=3, width=1, font=(UI_MONO, 9),
                            wrap=tk.WORD, relief=tk.FLAT, borderwidth=1)
     modoptionstb.pack(fill=tk.X)
 
@@ -948,7 +976,7 @@ if len(sys.argv) < 2: # no arguments passed, use GUI
     def startspring():
         gencmd(None)
         print('starting spring with', runcmd)
-        subprocess.Popen(shlex.split(runcmd), close_fds=True)
+        subprocess.Popen(host_cmd_prefix() + shlex.split(runcmd), close_fds=True)
 
     button_frame = ttk.Frame(root)
     button_frame.grid(row=4, column=0, sticky=tk.EW, padx=PAD, pady=(PAD // 2, PAD))
@@ -958,7 +986,7 @@ if len(sys.argv) < 2: # no arguments passed, use GUI
                command=startreplay).grid(row=0, column=0, sticky=tk.EW, padx=(0, PAD // 2))
     # Primary action: emphasize via ttk.Style (TButton can't easily get a
     # bold variant without a custom style, so we use a slightly bolder label).
-    style.configure('Primary.TButton', font=('TkDefaultFont', 10, 'bold'))
+    style.configure('Primary.TButton', font=(UI_SANS, 10, 'bold'))
     ttk.Button(button_frame, text="▶  Launch with selected settings",
                style='Primary.TButton',
                command=startspring).grid(row=0, column=1, sticky=tk.EW, padx=(PAD // 2, 0))

--- a/BAR_Debug_Launcher.py
+++ b/BAR_Debug_Launcher.py
@@ -12,6 +12,7 @@ import subprocess
 import shlex
 import sys
 import shutil
+import webbrowser
 import requests
 try:
     import py7zr
@@ -24,7 +25,15 @@ from parse_demo_file import Parse_demo_file
 
 from slpp import slpp
 
-from bar_launch.core import find_linux_launcher_binary as _find_linux_launcher_binary
+from bar_launch.core import Context, find_linux_launcher_binary as _find_linux_launcher_binary
+from bar_launch.engine_cmd import build_runcmd
+from bar_launch.intents import (
+    BOOT_CHOICES,
+    Intent,
+    PLAY_CHOICES,
+    default_boot,
+    resolve_intent,
+)
 
 #Try to figure out the BAR install path:
 barinstallpath = os.path.abspath(os.path.dirname(sys.argv[0])) 
@@ -238,8 +247,9 @@ def refresh():
         if '$VERSION' in gamename:
             modinfos[gamename] = {'modtype': '1', 'name': gamename}
 
-    # Surface locally-checked-out games (e.g. via Devtools' link::create) as
-    # [LOCAL] entries so the dropdown distinguishes them from rapid:// builds.
+    # Surface locally-checked-out games (anything symlinked or hardlinked
+    # into <data-dir>/games/) as [LOCAL] entries so the dropdown
+    # distinguishes them from rapid:// builds.
     gamespath = os.path.join(datafolder, 'games')
     if os.path.exists(gamespath):
         for gamedir in os.listdir(gamespath):
@@ -447,153 +457,535 @@ def try_start_replay(replayfilepath):
     #print (demo.header)
 
 
+class _Tooltip:
+    """Lightweight hover/focus tooltip. text_func is called at show-time so
+    each tooltip reflects the current selection rather than a stale snapshot."""
+    def __init__(self, widget, text_func, delay_ms=350):
+        self.widget = widget
+        self.text_func = text_func
+        self.delay_ms = delay_ms
+        self.tip = None
+        self.after_id = None
+        widget.bind('<Enter>', self._schedule, add='+')
+        widget.bind('<FocusIn>', self._schedule, add='+')
+        widget.bind('<Leave>', self._hide, add='+')
+        widget.bind('<FocusOut>', self._hide, add='+')
+        widget.bind('<ButtonPress>', self._hide, add='+')
+
+    def _schedule(self, _evt=None):
+        self._cancel()
+        self.after_id = self.widget.after(self.delay_ms, self._show)
+
+    def _cancel(self):
+        if self.after_id:
+            try: self.widget.after_cancel(self.after_id)
+            except Exception: pass
+            self.after_id = None
+
+    def _show(self):
+        text = self.text_func() or ""
+        if not text:
+            return
+        x = self.widget.winfo_rootx() + 16
+        y = self.widget.winfo_rooty() + self.widget.winfo_height() + 4
+        self.tip = tk.Toplevel(self.widget)
+        self.tip.wm_overrideredirect(True)
+        self.tip.wm_geometry(f"+{x}+{y}")
+        frame = tk.Frame(self.tip, background='#1f2937', borderwidth=0)
+        frame.pack()
+        tk.Label(frame, text=text, background='#1f2937', foreground='#f9fafb',
+                 justify=tk.LEFT, padx=10, pady=8,
+                 font=('TkDefaultFont', 9), wraplength=420).pack()
+
+    def _hide(self, _evt=None):
+        self._cancel()
+        if self.tip:
+            try: self.tip.destroy()
+            except Exception: pass
+            self.tip = None
+
+
 if len(sys.argv) < 2: # no arguments passed, use GUI
     root = tk.Tk()
-    #root = ThemedTk(theme='black')
-    ttk.Label(
-        text=f"Place this next to {launcher_binary_display} to scan for contents.\nhttps://github.com/beyond-all-reason/bar_debug_launcher by Beherith").pack(
-        fill=tk.X, padx=5, pady=5)
-
-
-    modoptionstb = tk.Text(root, height = 5, font=("Courier", 8))
-
-    cmdtext = tk.Text(root, height=7, font=("Courier", 8))
-    # config the root window
-    root.geometry('500x550')
+    # ----- Window-size floors (single edit point) -------------------------
+    # Final window size is max(MIN_*, measured content size). Edit these to
+    # taste -- if you want a smaller window, lower the floor. The measure
+    # block before mainloop() will still upsize past these if Tk reports a
+    # natural content size that won't fit, so the button row can't end up
+    # clipped, only the floor moves.
+    MIN_W, MIN_H = 480, 620
+    # ----------------------------------------------------------------------
+    root.geometry(f'{MIN_W}x{MIN_H}')
     root.resizable(True, True)
     root.title('BAR Replay and Debug Launcher')
-
-    #root.config(bg="#26242f")  
     try:
         root.iconbitmap('bar-icon.ico')
     except:
         print("Unable to find bar-icon.ico")
-    # label
-    ttk.Label(text="Select the engine version you want to use:").pack(fill=tk.X, padx=5, pady=5)
 
-    # create a combobox
+    # ttk theme: prefer 'clam' (flat, modern-ish look that ships with stock
+    # Tk on Linux/macOS/Windows). Falls back to whatever's available.
+    style = ttk.Style()
+    for _theme in ('clam', 'alt', 'default'):
+        if _theme in style.theme_names():
+            try:
+                style.theme_use(_theme)
+            except tk.TclError:
+                continue
+            break
+
+    # Custom styles for visual hierarchy.
+    style.configure('Hint.TLabel', foreground='#666')
+    style.configure('Link.TLabel', foreground='#2563eb')
+    style.configure('Section.TLabelframe', padding=10)
+    style.configure('Section.TLabelframe.Label', font=('TkDefaultFont', 10, 'bold'))
+
+    PAD = 8
+
+    # Root uses grid (not pack) so each section sits in its own reserved row.
+    # If the config block ever grows beyond expectations, the button row at
+    # row=4 still renders -- it can't be pushed off the bottom by overflow
+    # above. The cmd/mod text panels never grow (fixed line counts), so no
+    # row needs weight=1; weight stays 0 everywhere.
+    root.grid_columnconfigure(0, weight=1)
+
+    # Header / preamble: dim explainer on the left, "GitHub" link on the
+    # right. Tk has no native hyperlink, so we style a Label with Link.TLabel
+    # + hand cursor + click handler that opens the default browser.
+    header = ttk.Frame(root)
+    header.grid(row=0, column=0, sticky=tk.EW, padx=PAD, pady=(PAD, PAD // 2))
+    header.columnconfigure(0, weight=1)
+    # No wraplength: let the label keep its natural single-line width so
+    # winfo_reqwidth() picks it up and the window grows to match. Pinning
+    # wraplength to MIN_W forced wrapping whenever MIN_W < natural width.
+    ttk.Label(header,
+              text=f"Place this next to {launcher_binary_display} to scan for contents.",
+              style='Hint.TLabel', justify=tk.LEFT,
+              ).grid(row=0, column=0, sticky=tk.W)
+    _GH_URL = "https://github.com/beyond-all-reason/bar_debug_launcher"
+    _link = ttk.Label(header, text="GitHub ↗", style='Link.TLabel', cursor='hand2')
+    _link.grid(row=0, column=1, sticky=tk.E, padx=(PAD, 0))
+    _link.bind('<Button-1>', lambda e: webbrowser.open(_GH_URL))
+    _link.bind('<Enter>', lambda e: _link.configure(font=('TkDefaultFont', 9, 'underline')))
+    _link.bind('<Leave>', lambda e: _link.configure(font=('TkDefaultFont', 9)))
+
+    # ---------------------------------------------------------------------
+    # Intent-first config: Engine, then (Play, Source, Boot, Map) in a
+    # 2-column grid so labels and widgets line up. The ⓘ-square-button has
+    # been replaced with a less-jarring "Details…" link next to the source
+    # combobox -- same affordance, calmer presentation.
+    # ---------------------------------------------------------------------
+
+    PLAY_LABELS = {
+        "chobby": "Chobby (lobby/menu)",
+        "bar":    "BAR (game directly)",
+        "replay": "Replay…",
+    }
+    PLAY_BY_LABEL = {v: k for k, v in PLAY_LABELS.items()}
+
+    def _local_available(play):
+        if play == "replay":
+            return False
+        try:
+            resolve_intent(Intent(play, "local", default_boot(play)), modinfos)
+            return True
+        except (KeyError, ValueError):
+            return False
+
+    def _pinned_versions(play):
+        versions = set()
+        if play == "chobby":
+            wanted_modtype = {"5", "0"}
+        elif play == "bar":
+            wanted_modtype = {"1"}
+        else:
+            return []
+        for label, mi in modinfos.items():
+            if label.startswith("[LOCAL]"):
+                continue
+            if str(mi.get("modtype", "")) not in wanted_modtype:
+                continue
+            m = re.search(r"(\S+)\s+\$VERSION", label)
+            if m:
+                versions.add(m.group(1))
+        return sorted(versions, reverse=True)
+
+    def _local_source_paths(play):
+        if play == "replay":
+            return []
+        gamespath = os.path.join(datafolder, "games")
+        if not os.path.isdir(gamespath):
+            return []
+        wanted_modtype = "1" if play == "bar" else "5"
+        out = []
+        for gamedir in sorted(os.listdir(gamespath)):
+            label = f"[LOCAL] {gamedir}"
+            mi = modinfos.get(label)
+            if mi and str(mi.get("modtype", "")) == wanted_modtype:
+                out.append(os.path.join(gamespath, gamedir))
+        return out
+
+    config_frame = ttk.LabelFrame(root, text='What to launch', style='Section.TLabelframe')
+    config_frame.grid(row=1, column=0, sticky=tk.EW, padx=PAD, pady=PAD // 2)
+    # Column 1 is the wide widget column; column 2 holds inline addons (link).
+    config_frame.columnconfigure(1, weight=1)
+
+    # Three orthogonal source axes (engine / chobby / game) each get their
+    # own dropdown. Whichever is "active" depends on Play; the inactive ones
+    # grey out (state=disabled) but their values persist so toggling Play
+    # doesn't blow away your pin on the other axis.
     selected_engine = tk.StringVar()
-    engine_cb = ttk.Combobox(root, textvariable=selected_engine, height=min(len(engines), 40))
-    engine_cb['values'] = sorted(engines.keys())
-    engine_cb.set(sorted(engines.keys())[-1])
-    # prevent typing a value
-    engine_cb['state'] = 'readonly'
-    # place the widget
-    engine_cb.pack(fill=tk.X, padx=5, pady=5)
-
-    ttk.Label(text="Select the game/menu version you want to run:").pack(fill=tk.X, padx=5, pady=5)
-
-    # create a combobox
-    selected_game = tk.StringVar()
-    game_cb = ttk.Combobox(root, textvariable=selected_game)
-    game_cb['values'] = list(modinfos.keys())
-    game_cb.set(list(modinfos.keys())[0])
-    # prevent typing a value
-    game_cb['state'] = 'readonly'
-    # place the widget
-    game_cb.pack(fill=tk.X, padx=5, pady=5)
-
-    ttk.Label(text="Select a map if you want to test the game directly. Not all maps will work.").pack(fill=tk.X, padx=5,
-                                                                                                    pady=5)
-
-    # create a combobox
+    selected_play_label = tk.StringVar()
+    selected_chobby_source = tk.StringVar()
+    selected_game_source = tk.StringVar()
+    selected_boot = tk.StringVar()
     selected_map = tk.StringVar()
-    map_cb = ttk.Combobox(root, textvariable=selected_map, height=min(len(maps), 50))
+
+    def _grid_label(text, row):
+        ttk.Label(config_frame, text=text).grid(row=row, column=0, sticky=tk.W, padx=(0, PAD), pady=4)
+
+    # Engine source row -- the engine binary. Always active for chobby/bar;
+    # replay overrides via the demo header but the default still comes from here.
+    _grid_label("Engine source", 0)
+    engine_cb = ttk.Combobox(config_frame, textvariable=selected_engine, state='readonly',
+                             height=min(len(engines), 40))
+    engine_cb['values'] = sorted(engines.keys())
+    _default_engine = next(
+        (k for k in engines.keys() if "local-build" in k),
+        sorted(engines.keys())[-1],
+    )
+    engine_cb.set(_default_engine)
+    engine_cb.grid(row=0, column=1, columnspan=2, sticky=tk.EW, pady=4)
+
+    # Play row -- which thing to launch (chobby vs bar vs replay).
+    _grid_label("Play", 1)
+    play_cb = ttk.Combobox(config_frame, textvariable=selected_play_label, state="readonly",
+                           values=[PLAY_LABELS[p] for p in PLAY_CHOICES])
+    play_cb.set(PLAY_LABELS["chobby"])
+    play_cb.grid(row=1, column=1, columnspan=2, sticky=tk.EW, pady=4)
+
+    # Chobby source -- active when Play=chobby.
+    _grid_label("Chobby source", 2)
+    chobby_source_cb = ttk.Combobox(config_frame, textvariable=selected_chobby_source, state="readonly")
+    chobby_source_cb.grid(row=2, column=1, columnspan=2, sticky=tk.EW, pady=4)
+
+    # Game source -- active when Play=BAR.
+    _grid_label("Game source", 3)
+    game_source_cb = ttk.Combobox(config_frame, textvariable=selected_game_source, state="readonly")
+    game_source_cb.grid(row=3, column=1, columnspan=2, sticky=tk.EW, pady=4)
+
+    # Boot row
+    _grid_label("Boot", 4)
+    boot_cb = ttk.Combobox(config_frame, textvariable=selected_boot, state="readonly",
+                           values=list(BOOT_CHOICES), width=12)
+    boot_cb.grid(row=4, column=1, columnspan=2, sticky=tk.W, pady=4)
+
+    # Map row
+    _grid_label("Map", 5)
+    map_cb = ttk.Combobox(config_frame, textvariable=selected_map, state='readonly',
+                          height=min(len(maps), 50))
     map_cb['values'] = ['Ill choose my own once ingame'] + sorted(maps.keys())
     map_cb.set('Ill choose my own once ingame')
-            # prevent typing a value
-    map_cb['state'] = 'readonly'
-    # place the widget
-    map_cb.pack(fill=tk.X, padx=5, pady=5)
+    map_cb.grid(row=5, column=1, columnspan=2, sticky=tk.EW, pady=4)
+
+    # One-line "hover for details" hint under the dropdowns -- a single
+    # discoverability cue rather than six separate static helpers.
+    ttk.Label(config_frame,
+              text="hover any field for technical details · greyed sources are inactive but persist",
+              style='Hint.TLabel').grid(row=6, column=0, columnspan=3, sticky=tk.W, pady=(PAD // 2, 0))
+
+    # Generated command preview (smaller; full command always visible).
+    cmd_frame = ttk.LabelFrame(root, text='Generated command', style='Section.TLabelframe')
+    cmd_frame.grid(row=2, column=0, sticky=tk.EW, padx=PAD, pady=PAD // 2)
+    # width=1 so Tk doesn't claim the default 80-column natural width as the
+    # window's required width -- the LabelFrame stretches via fill=tk.X and
+    # the inner Text follows. Without this the Text alone forces ~560px.
+    cmdtext = tk.Text(cmd_frame, height=4, width=1, font=("Courier", 9),
+                      wrap=tk.WORD, relief=tk.FLAT, borderwidth=0,
+                      background="#f5f5f5")
+    cmdtext.pack(fill=tk.X)
+
+    # Modoptions
+    mod_frame = ttk.LabelFrame(root, text='Additional modoptions', style='Section.TLabelframe')
+    mod_frame.grid(row=3, column=0, sticky=tk.EW, padx=PAD, pady=PAD // 2)
+    modoptionstb = tk.Text(mod_frame, height=3, width=1, font=("Courier", 9),
+                           wrap=tk.WORD, relief=tk.FLAT, borderwidth=1)
+    modoptionstb.pack(fill=tk.X)
+
+    # ---------------------------------------------------------------------
+    # Per-field tooltips. Each text_func is called at hover time so it
+    # reflects the *current* selection -- no stale strings.
+    # ---------------------------------------------------------------------
+    def _engine_tip():
+        eng = selected_engine.get()
+        path = engines.get(eng, '?')
+        note = ("Local dev build (linked into <data-dir>/engine/local-build/)."
+                if "local-build" in eng
+                else "Cached engine release.")
+        return (f"Engine: {eng}\n"
+                f"Binary: {path}\n\n{note}\n\n"
+                "Used as the spring(.exe) executable; passed --isolation "
+                "and --write-dir <data-dir> regardless of how it boots.")
+
+    def _play_tip():
+        play = PLAY_BY_LABEL.get(selected_play_label.get(), '?')
+        return {
+            'chobby': ("Chobby — the lobby/menu (room browser, settings, replays).\n\n"
+                       "Resolves to a 'menu' archive: modtype 0 when booting via the "
+                       "AppImage launcher, modtype 5 when booting the engine directly "
+                       "with --menu."),
+            'bar':    ("Beyond All Reason game directly (skirmish, debugging).\n\n"
+                       "Resolves to a 'game' archive (modtype 1). The launcher writes "
+                       "bar_debug_launcher_script.txt with the chosen map and the engine "
+                       "reads that as its start script."),
+            'replay': (".sdfz replay file. The Play dropdown sets the mode but the file "
+                       "itself is picked via the 'Open and launch a replay' button below. "
+                       "Engine version is taken from the demo header, not the Engine "
+                       "dropdown above."),
+        }.get(play, '')
+
+    def _source_axis_tip(axis_play, source_var):
+        # Shared body for the chobby/game source tooltips. axis_play is the
+        # play this dropdown represents ("chobby" or "bar"); source_var is
+        # its StringVar. The tooltip flags whether the axis is currently
+        # active for the launch (Play matches) so the user can tell at a
+        # glance which dropdown drives the resolved command.
+        active_play = PLAY_BY_LABEL.get(selected_play_label.get(), '?')
+        active = (active_play == axis_play)
+        src_kind, src_arg = _parse_source(source_var.get())
+        boot = selected_boot.get() or default_boot(axis_play)
+        what = "Chobby (lobby/menu)" if axis_play == "chobby" else "BAR (game)"
+        head = (f"{what} source — ACTIVE for this launch.\n\n" if active
+                else f"{what} source — inactive (Play is set to {active_play!r}). "
+                     f"Value persists for when you switch back.\n\n")
+        head += {
+            'latest': f"Latest test channel — pulled at run time via "
+                      f"{'rapid://byar-chobby:test' if axis_play == 'chobby' else 'rapid://byar:test'}.",
+            'local':  f"Local {what} checkout — a working tree linked into <data-dir>/games/.",
+            'pinned': f"Pinned cached {what} version ({src_arg or '?'}).",
+        }.get(src_kind, '')
+        try:
+            label, mi = resolve_intent(Intent(axis_play, src_kind, boot, version=src_arg), modinfos)
+            body = (f"\n\nResolves to: {label}\n"
+                    f"Archive name: {mi.get('name', '?')}\n"
+                    f"modtype: {mi.get('modtype', '?')} "
+                    f"({'AppImage launcher' if mi.get('modtype') == '0' else 'engine direct'})")
+        except (KeyError, ValueError) as e:
+            body = f"\n\nResolve error: {e}"
+        if src_kind == 'local':
+            paths = _local_source_paths(axis_play)
+            if paths:
+                body += "\n\nCheckout: " + paths[0]
+        return head + body
+
+    def _chobby_source_tip(): return _source_axis_tip("chobby", selected_chobby_source)
+    def _game_source_tip():   return _source_axis_tip("bar",    selected_game_source)
+
+    def _boot_tip():
+        return {
+            'launcher': ("Boot via Beyond-All-Reason.AppImage.\n\n"
+                         "Writes a dev-lobby JSON, then runs the AppImage with -c <config>. "
+                         "The AppImage handles splash, auto-update, and rapid:// downloads "
+                         "of any missing assets. Slower start, but matches the real-player "
+                         "experience."),
+            'engine':   ("Boot the engine binary directly.\n\n"
+                         "Runs spring(.exe) with --menu <name> (chobby) or a generated "
+                         "start script (bar). Faster, no launcher overhead, but breaks if "
+                         "any assets are missing — there's no download retry layer."),
+        }.get(selected_boot.get(), '')
+
+    def _map_tip():
+        play = PLAY_BY_LABEL.get(selected_play_label.get(), '?')
+        if play != 'bar':
+            return "Map is only used when Play = BAR. Ignored for chobby and replays."
+        mp = selected_map.get()
+        if mp == 'Ill choose my own once ingame':
+            return ("No map preselected.\n\nThe engine starts without a start script; "
+                    "you'll choose a map from the in-game skirmish menu.")
+        return (f"Map: {mp}\n\nWill write bar_debug_launcher_script.txt containing a "
+                "[game] block with mapname=<this>, gametype=<resolved game name>, and "
+                "any modoptions you've added below. Engine reads that as its start "
+                "script and goes straight into the match.")
+
+    _Tooltip(engine_cb,        _engine_tip)
+    _Tooltip(play_cb,          _play_tip)
+    _Tooltip(chobby_source_cb, _chobby_source_tip)
+    _Tooltip(game_source_cb,   _game_source_tip)
+    _Tooltip(boot_cb,          _boot_tip)
+    _Tooltip(map_cb,           _map_tip)
+
+    def _parse_source(s):
+        if s == "Latest":
+            return ("latest", None)
+        if s.startswith("Local checkout"):
+            return ("local", None)
+        if s.startswith("Pinned: "):
+            return ("pinned", s[len("Pinned: "):])
+        return ("latest", None)
+
+    def _source_options_for(play):
+        """Return (opts list, default-local-opt-if-any) for one source axis."""
+        opts = ["Latest"]
+        local_opt = None
+        if _local_available(play):
+            paths = _local_source_paths(play)
+            tag = paths[0] if paths else "<unknown path>"
+            local_opt = f"Local checkout ({tag})"
+            opts.append(local_opt)
+        for v in _pinned_versions(play):
+            opts.append(f"Pinned: {v}")
+        return opts, local_opt
+
+    def _populate_chobby_sources():
+        opts, local_opt = _source_options_for("chobby")
+        chobby_source_cb['values'] = opts
+        if selected_chobby_source.get() not in opts:
+            selected_chobby_source.set(local_opt or opts[0])
+
+    def _populate_game_sources():
+        opts, local_opt = _source_options_for("bar")
+        game_source_cb['values'] = opts
+        if selected_game_source.get() not in opts:
+            selected_game_source.set(local_opt or opts[0])
+
+    def _refresh_states():
+        """Grey out the source dropdowns / Map / Boot that don't apply to
+        the current Play. The disabled state preserves the StringVar's value
+        -- it's strictly visual + click-blocking."""
+        play = PLAY_BY_LABEL.get(selected_play_label.get(), "chobby")
+        chobby_source_cb.configure(state="readonly" if play == "chobby" else "disabled")
+        game_source_cb.configure(state="readonly" if play == "bar" else "disabled")
+        map_cb.configure(state="readonly" if play == "bar" else "disabled")
+        boot_cb.configure(state="readonly" if play in ("chobby", "bar") else "disabled")
+        engine_cb.configure(state="readonly" if play != "replay" else "disabled")
+
+    _populate_chobby_sources()
+    _populate_game_sources()
+    selected_boot.set(default_boot("chobby"))
 
     runcmd = ""
 
+    def _ctx():
+        # Wrap the GUI's existing globals as a Context so we can reuse the
+        # CLI's command builder. build_runcmd is the canonical place that
+        # encodes how (modinfo, engine, map) becomes the engine invocation.
+        return Context(
+            barinstallpath=barinstallpath,
+            datafolder=datafolder,
+            launcher_binary=launcher_binary,
+            engines=engines,
+            modinfos=modinfos,
+        )
 
-    def genscript(map, game):
-        modopts = modoptionstb.get('1.0',tk.END)
-        print (modopts)
-        scripttxt =  scriptbase % (modopts, map, game)
-        scriptfile = open("bar_debug_launcher_script.txt", 'w')
-        scriptfile.write(scripttxt)
-        scriptfile.close()
-        print('Generated script:', scripttxt)
-
-
-    def gencmd(event):
+    def gencmd(event=None):
         global runcmd
-        mygame = selected_game.get()
-        modinfo = modinfos[mygame]
+        play = PLAY_BY_LABEL.get(selected_play_label.get(), "chobby")
+        if play == "replay":
+            runcmd = ""
+            cmdtext.delete('1.0', tk.END)
+            cmdtext.insert('1.0', "Use the 'Open and launch a replay' button below.")
+            return
+        # Pick the active source axis for this Play. The other source
+        # dropdown's value is ignored by this launch but stays set for next
+        # time (see _refresh_states for the visual greying).
+        if play == "chobby":
+            src_str = selected_chobby_source.get()
+        else:  # bar
+            src_str = selected_game_source.get()
+        src_kind, src_arg = _parse_source(src_str)
+        boot = selected_boot.get() or default_boot(play)
+        try:
+            label, modinfo = resolve_intent(
+                Intent(play, src_kind, boot, version=src_arg), modinfos
+            )
+        except (KeyError, ValueError) as e:
+            runcmd = ""
+            cmdtext.delete('1.0', tk.END)
+            cmdtext.insert('1.0', f"# could not resolve intent: {e}")
+            return
         myengine = selected_engine.get()
         mymap = selected_map.get()
-        if modinfo['modtype'] == '5':
-            runcmd = f'"{engines[myengine]}"  --isolation --write-dir "{os.path.join(barinstallpath, datafolder)}" --menu "{modinfo["name"]}"'
-        elif modinfo['modtype'] == '1':
-            if mymap != 'Ill choose my own once ingame':
-                genscript(mymap, modinfo["name"])
-                runcmd = f'"{engines[myengine]}"  --isolation --write-dir "{os.path.join(barinstallpath, datafolder)}" bar_debug_launcher_script.txt'
-            else:
-                runcmd = f'"{engines[myengine]}"  --isolation --write-dir "{os.path.join(barinstallpath, datafolder)}"'
-        elif modinfo['modtype'] == '0':
-            configdev = "bar_debug_launcher_config.json"
-            bar_debug_launcher_config_file = open(configdev, 'w')
-            bar_debug_launcher_config_file.write(
-                """{
-                    "title": "Beyond All Reason",
-                    "setups": [
-                        {
-                            "package": {
-                                "id": "dev-lobby",
-                                "display": "Dev Lobby"
-                            },
-                            "downloads": {
-                                "engines": ["%s"]
-                            },
-                            "no_start_script": true,
-                            "no_downloads": true,
-                            "auto_start": true,
-                            "launch": {
-                                "start_args": ["--menu", "%s"]
-                            }
-                        }
-                    ]
-                }""" % (myengine, modinfo['name'])) # engine needs "105.1.1-941-g941148f bar" format
-            bar_debug_launcher_config_file.close()
-
-            runcmd = f'"{os.path.join(barinstallpath, launcher_binary)}" -c "{os.path.join(barinstallpath, configdev)}"'
-
-        print(runcmd)
+        modopts = modoptionstb.get('1.0', tk.END)
+        try:
+            runcmd = build_runcmd(_ctx(), modinfo, myengine, mymap, modopts)
+        except (KeyError, ValueError) as e:
+            runcmd = ""
+            cmdtext.delete('1.0', tk.END)
+            cmdtext.insert('1.0', f"# build_runcmd error: {e}")
+            return
+        print(f"[{label}]", runcmd)
         cmdtext.delete('1.0', tk.END)
         cmdtext.insert('1.0', str(runcmd))
 
+    def _on_play_changed(event=None):
+        play = PLAY_BY_LABEL.get(selected_play_label.get(), "chobby")
+        # Re-default boot for the new play; user can still override.
+        if play != "replay":
+            selected_boot.set(default_boot(play))
+        _refresh_states()
+        gencmd()
 
-    engine_cb.bind('<<ComboboxSelected>>', gencmd)
-    game_cb.bind('<<ComboboxSelected>>', gencmd)
-    map_cb.bind('<<ComboboxSelected>>', gencmd)
+    engine_cb.bind('<<ComboboxSelected>>',        gencmd)
+    play_cb.bind('<<ComboboxSelected>>',          _on_play_changed)
+    chobby_source_cb.bind('<<ComboboxSelected>>', gencmd)
+    game_source_cb.bind('<<ComboboxSelected>>',   gencmd)
+    boot_cb.bind('<<ComboboxSelected>>',          gencmd)
+    map_cb.bind('<<ComboboxSelected>>',           gencmd)
 
-    ttk.Label(text="This is the command that will be run:").pack(fill=tk.X, padx=5, pady=5)
-    cmdtext.pack(fill=tk.X)
-    ttk.Label(text="Additional modoptions:").pack(fill=tk.X, padx=5, pady=5)
-    modoptionstb.pack(fill = tk.X)
+    # Initial state-toggle + first command render.
+    _refresh_states()
 
     def startreplay():
         filetypes = [('BAR Replay Files', '*.sdfz'),
                     ('All files', '*.*')]
-        filename = filedialog.askopenfilename(title = 'Select a replay to watch', initialdir = os.path.join(barinstallpath, datafolder, 'demos'), filetypes = filetypes)
-        print (filename)
+        filename = filedialog.askopenfilename(title='Select a replay to watch',
+                                              initialdir=os.path.join(barinstallpath, datafolder, 'demos'),
+                                              filetypes=filetypes)
+        print(filename)
         if filename:
             try_start_replay(filename)
-
-    tk.Button(root, text="Open and launch a replay", command=startreplay).pack(side=tk.BOTTOM, fill=tk.X)
 
     def startspring():
         gencmd(None)
         print('starting spring with', runcmd)
-        subprocess.Popen(shlex.split(runcmd),close_fds=True )
+        subprocess.Popen(shlex.split(runcmd), close_fds=True)
 
-
-    tk.Button(root, text="Start with the above selected settings", command=startspring).pack(fill=tk.X)
+    button_frame = ttk.Frame(root)
+    button_frame.grid(row=4, column=0, sticky=tk.EW, padx=PAD, pady=(PAD // 2, PAD))
+    button_frame.columnconfigure(0, weight=1)
+    button_frame.columnconfigure(1, weight=1)
+    ttk.Button(button_frame, text="Open and launch a replay…",
+               command=startreplay).grid(row=0, column=0, sticky=tk.EW, padx=(0, PAD // 2))
+    # Primary action: emphasize via ttk.Style (TButton can't easily get a
+    # bold variant without a custom style, so we use a slightly bolder label).
+    style.configure('Primary.TButton', font=('TkDefaultFont', 10, 'bold'))
+    ttk.Button(button_frame, text="▶  Launch with selected settings",
+               style='Primary.TButton',
+               command=startspring).grid(row=0, column=1, sticky=tk.EW, padx=(PAD // 2, 0))
 
     gencmd(None)  # init defaults
+
+    # Hard sizing: ask Tk what each widget actually rendered to (which captures
+    # theme padding, system font DPI, HiDPI scaling -- everything the
+    # estimated-by-eyeball geometry hint above gets wrong) and size the window
+    # from that, with a floor. Without this, on themes/DPIs where comboboxes
+    # render taller than expected, the bottom rows get pushed off-screen.
+    root.update_idletasks()
+    req_w = root.winfo_reqwidth()
+    req_h = root.winfo_reqheight()
+    # MIN_W/MIN_H are floors -- final size is at least MIN_*, but grows
+    # past that if natural content needs more room. This makes the window
+    # wide enough to fit the header without wrapping, regardless of MIN_W.
+    # If you want hard MIN_* (no auto-grow), replace `max(...)` with the
+    # MIN_* literal.
+    win_w = max(MIN_W, req_w + 8)
+    win_h = max(MIN_H, req_h + 8)
+    # minsize first so the WM has the lower bound. Schedule the resize via
+    # after_idle so it runs AFTER Tk's auto-fit-to-content pass -- otherwise
+    # Tk shrinks the window back to natural content size when our requested
+    # width exceeds it (the "MIN_W up doesn't work" failure).
+    root.minsize(win_w, win_h)
+    root.after_idle(lambda: root.geometry(f"{win_w}x{win_h}"))
     root.mainloop()
 else:
     #arg passed, it better be a replay file

--- a/BAR_Debug_Launcher.py
+++ b/BAR_Debug_Launcher.py
@@ -25,7 +25,18 @@ from parse_demo_file import Parse_demo_file
 
 from slpp import slpp
 
-from bar_launch.core import Context, find_linux_launcher_binary as _find_linux_launcher_binary, host_cmd_prefix
+from bar_launch.core import (
+    build_context,
+    engine_binary,
+    engine_download_baseurl,
+    engine_download_baseurl_new,
+    engine_download_baseurl_newest,
+    find_linux_datadir,
+    find_linux_launcher_binary as _find_linux_launcher_binary,
+    host_cmd_prefix,
+    launcher_binary_display,
+    prd_binary,
+)
 from bar_launch.engine_cmd import build_runcmd
 from bar_launch.intents import (
     BOOT_CHOICES,
@@ -60,222 +71,41 @@ if False:
 
 #maps = ['Ill choose my own once ingame']
 
-def find_linux_datadir():
-    # Searches for the BAR install directory in the ~same was as launcher
-    # and returns absolute path
-    try:
-        documents = subprocess.check_output(
-            ['xdg-user-dir', 'DOCUMENTS'], encoding='utf-8').strip()
-    except:
-        documents = os.path.expanduser("~")  # Yep, that's fallback
-    if os.path.exists(os.path.join(documents, 'Beyond All Reason')):
-        return os.path.join(documents, 'Beyond All Reason')
-
-    state_home = os.getenv('XDG_STATE_HOME',
-        default=os.path.join(os.path.expanduser("~"), '.local', 'state'))
-    return os.path.join(state_home, 'Beyond All Reason')
-
 def find_linux_launcher_binary():
     # Honors $BAR_APPIMAGE_PATH and --launcher-binary first; falls back to
     # the legacy cwd scan so the standalone "drop next to the AppImage and
     # double-click" workflow keeps working.
     return _find_linux_launcher_binary(barinstallpath)
 
+# Platform constants (engine/pr-downloader binary names, download URL
+# templates, launcher display name) come from bar_launch.core so the GUI and
+# CLI can't drift; core raises on unsupported platforms at import time.
 if platform.system() == 'Windows':
-    engine_binary = 'spring.exe'
-    prd_binary = 'pr-downloader.exe'
     datafolder = os.environ.get("BAR_DATA_DIR", 'data')
-    launcher_binary_display = launcher_binary = 'Beyond-All-Reason.exe'
-    engine_download_baseurl = 'https://github.com/beyond-all-reason/spring/releases/download/spring_bar_%7BBAR105%7D{enginebaseversion}/spring_bar_.BAR105.{enginebaseversion}_windows-64-minimal-portable.7z'
-    engine_download_baseurl_new = 'https://github.com/beyond-all-reason/spring/releases/download/{enginebaseversion}/spring_bar_.{releaseID}.{enginebaseversion}_windows-64-minimal-portable.7z'
-    engine_download_baseurl_newest = 'https://github.com/beyond-all-reason/RecoilEngine/releases/download/{enginebaseversion}/recoil_{enginebaseversion}_amd64-windows.7z'
-elif platform.system() == 'Linux':
-    engine_binary = 'spring'
-    prd_binary = 'pr-downloader'
-    # Later we depend on that os.join(barinstallpath, datafolder) returns
-    # datafolder when datafolder is absolute path.
-    datafolder = find_linux_datadir()
-    launcher_binary = find_linux_launcher_binary()
-    launcher_binary_display= "Beyond-All-Reason AppImage"
-    engine_download_baseurl = 'https://github.com/beyond-all-reason/spring/releases/download/spring_bar_%7BBAR105%7D{enginebaseversion}/spring_bar_.BAR105.{enginebaseversion}_linux-64-minimal-portable.7z'
-    engine_download_baseurl_new = 'https://github.com/beyond-all-reason/spring/releases/download/{enginebaseversion}/spring_bar_.{releaseID}.{enginebaseversion}_linux-64-minimal-portable.7z'
-    engine_download_baseurl_newest = 'https://github.com/beyond-all-reason/RecoilEngine/releases/download/{enginebaseversion}/recoil_{enginebaseversion}_amd64-linux.7z'
+    launcher_binary = 'Beyond-All-Reason.exe'
 else:
-    raise Exception('Unsupported platform')
+    # Later we depend on that os.join(barinstallpath, datafolder) returns
+    # datafolder when datafolder is absolute path. BAR_DATA_DIR is how
+    # `python -m bar_launch --data-dir ...` hands the data dir to the GUI.
+    datafolder = os.environ.get("BAR_DATA_DIR") or find_linux_datadir()
+    launcher_binary = find_linux_launcher_binary()
 
 
-archivecache = {} # maps gamename/mapname to filename
 maps = {}
 games = {}
 menus = {}
 engines = {}
 modinfos = {}
-
-scriptbase = """
-[game]
-{
-    [allyteam1]
-    {
-        numallies=0;
-    }
-    [team1]
-    {
-        teamleader=0;
-        allyteam=1;
-    }
-    [ai0]
-    {
-        shortname=NullAI;
-        name=NullAI;
-        version=0.1;
-        team=1;
-        host=0;
-    }
-    [modoptions]
-    {
-        %s
-    }
-    [allyteam0]
-    {
-        numallies=0;
-    }
-    [team0]
-    {
-        teamleader=0;
-        allyteam=0;
-    }
-    [player0]
-    {
-        team=0;
-        name=DebugLauncher;
-    }
-    mapname=%s;
-    myplayername=DebugLauncher;
-    ishost=1;
-    gametype=%s;
-    nohelperais=0;
-}"""
-
-# returns a dict of engineversion:absolutespringexepath
-def findengines(enginefolder):
-    engines = {}
-    enginedirs  = {}
-    if os.path.exists(enginefolder):
-        for engineversion in os.listdir(enginefolder):
-            enginedir = os.path.join(enginefolder, engineversion)
-            if os.path.isdir(enginedir) and os.path.exists(os.path.join(enginedir, engine_binary)):
-                enginepath = os.path.join(enginedir, engine_binary)
-                print(f"Found engine version {engineversion} in path: {enginepath}")
-                engines[engineversion] = enginepath
-    if len(engines) == 0:
-        engines["NO ENGINES FOUND!"] = "NO ENGINES FOUND!"
-    return engines,enginedirs
-
-# returns three dicts from archivecach
-def parsecache(path):
-    global archivecache           
-    maps = {} # key archive name to value filename
-    games = {}
-    menus = {}
-    try:
-        cachefiles = []
-        for item in os.listdir(path):
-            itempath = os.path.join(path, item)
-            if os.path.isdir(itempath):
-                for archivecachefile in os.listdir(itempath):
-                    if 'archivecache' in archivecachefile.lower() and archivecachefile.lower().endswith('.lua'):
-                        archivecachefilepath = os.path.join(itempath, archivecachefile)
-                        lastmodified = os.path.getmtime(archivecachefilepath)
-                        print ("Found a cache file", item, archivecachefile, "last modified:", lastmodified)
-                        cachefiles.append((archivecachefilepath, lastmodified))
-            elif 'archivecache' in item.lower() and item.lower().endswith('.lua'):
-                lastmodified = os.path.getmtime(itempath)
-                print ("Found a cache file (direct)", item, "last modified:", lastmodified)
-                cachefiles.append((itempath, lastmodified))
-
-        if len(cachefiles) > 0:
-            cachefiles = sorted(cachefiles, key = lambda x: x[1], reverse = True)
-            archivecachefilepath = cachefiles[0][0]
-            print ("Loading Archive Cache File:", archivecachefilepath)
-            archivecachecontents = open(archivecachefilepath).read()
-            archivetable = '{' + archivecachecontents.partition('{')[2].rpartition('}')[0] +  '}'
-            archivetable = slpp.decode(archivetable)
-            for archive in archivetable['archives']:
-                if 'archivedata' in archive and 'modtype' in archive['archivedata']:
-                    archivedata = archive['archivedata']
-                    modtype = archivedata['modtype']
-                    if modtype == 3: # map
-                        maps[archivedata['name']] = archive['name']
-                    elif modtype == 5: #menu
-                        menus[archivedata['name']] = archive['name']
-                    elif modtype == 1: #game
-                        games[archivedata['name']] = archive['name']
-            print (f"Found {len(maps)} maps, {len(games)} games, {len(menus)} menus")
-    except Exception as e:
-        print ("parsecache error, dont code blind!", e)
-    return maps, games, menus
-
-def parsemodinfo(path):
-    try:
-        with open(path, 'r') as f:
-            contents = f.read()
-        table_str = '{' + contents.partition('{')[2].rpartition('}')[0] + '}'
-        return slpp.decode(table_str)
-    except Exception as e:
-        print(f"Error parsing {path}: {e}")
-        return None
+ctx = None  # bar_launch.core.Context built by refresh()
 
 def refresh():
-    global modinfos
-    #global enginepaths
-    #global enginedirs
-    global maps, games, menus, engines, enginedirs
-    maps, games, menus = parsecache(os.path.join(barinstallpath, datafolder, "cache"))
-    engines, enginedirs = findengines(os.path.join(barinstallpath, datafolder, "engine"))
-
-    #parsemaps()
-    # check for bar.sdd
-    
-    modinfos['Spring-launcher with rapid://byar-chobby:test'] = {'modtype': '0', 'name': 'rapid://byar-chobby:test'}
-    modinfos['Latest BYAR Chobby Lobby: rapid://byar-chobby:test'] = {'name': 'rapid://byar-chobby:test', 'version': '', 'modtype': '5'}
-    modinfos['Latest BAR Game: rapid://byar:test'] = {'name': 'rapid://byar:test', 'version': '', 'modtype': '1'}
-    for menuname in menus.keys():
-        if '$VERSION' in menuname:
-            modinfos[f'Spring-launcher with {menuname}'] = {'modtype': '0', 'name': menuname}
-            modinfos[f'{menuname} (no launcher)'] = {'modtype': '5', 'name': menuname}
-    for gamename in games.keys():
-        if '$VERSION' in gamename:
-            modinfos[gamename] = {'modtype': '1', 'name': gamename}
-
-    # Surface locally-checked-out games (anything symlinked or hardlinked
-    # into <data-dir>/games/) as [LOCAL] entries so the dropdown
-    # distinguishes them from rapid:// builds.
-    gamespath = os.path.join(datafolder, 'games')
-    if os.path.exists(gamespath):
-        for gamedir in os.listdir(gamespath):
-            gamepath = os.path.join(gamespath, gamedir)
-            if not os.path.isdir(gamepath):
-                continue
-            modinfopath = os.path.join(gamepath, 'modinfo.lua')
-            if not os.path.exists(modinfopath):
-                continue
-            modinfo = parsemodinfo(modinfopath)
-            if not (modinfo and 'name' in modinfo):
-                continue
-            base_name = modinfo['name']
-            version = modinfo.get('version', '')
-            if version == '$VERSION' and '$VERSION' not in base_name:
-                name = f"{base_name} $VERSION"
-            else:
-                name = base_name
-            mtype = str(modinfo.get('modtype', '1'))
-            display_name = f"[LOCAL] {gamedir}"
-            modinfos[display_name] = {'modtype': mtype, 'name': name}
-            if mtype == '5':
-                modinfos[f"[LOCAL] Spring-launcher with {gamedir}"] = {'modtype': '0', 'name': name}
-
-    for k, v in modinfos.items():
-        print(k, v)
+    """(Re)scan the BAR install via the shared bar_launch.core.build_context
+    and mirror the results into the GUI's module globals."""
+    global ctx, maps, games, menus, engines, modinfos
+    ctx = build_context(barinstallpath, datafolder, launcher_binary)
+    maps, games, menus = ctx.maps, ctx.games, ctx.menus
+    engines = ctx.engines
+    modinfos = ctx.modinfos
 
 refresh()
 
@@ -514,14 +344,16 @@ if len(sys.argv) < 2: # no arguments passed, use GUI
     # that and pin to the best available scalable family so text renders & scales.
     # BAR_TK_SCALING=<float> overrides the DPI-derived scaling for manual tuning.
     import tkinter.font as _tkfont
-    _avail = {f.lower(): f for f in _tkfont.families(root)}
-    def _pick_family(prefs, fallback):
-        for _p in prefs:
-            if _p.lower() in _avail:
-                return _avail[_p.lower()]
-        return fallback
     _default = _tkfont.nametofont('TkDefaultFont')
     if _default.actual('family').lower() == 'fixed':
+        # Enumerating every installed family is slow on font-heavy systems,
+        # so only pay for it on the broken-Tk path that actually needs it.
+        _avail = {f.lower(): f for f in _tkfont.families(root)}
+        def _pick_family(prefs, fallback):
+            for _p in prefs:
+                if _p.lower() in _avail:
+                    return _avail[_p.lower()]
+            return fallback
         UI_SANS = _pick_family(['DejaVu Sans', 'Noto Sans', 'Liberation Sans', 'Helvetica', 'Arial'], 'Liberation Sans')
         UI_MONO = _pick_family(['DejaVu Sans Mono', 'Liberation Mono', 'Noto Sans Mono', 'Courier New'], 'Liberation Mono')
         for _name in _tkfont.names(root):
@@ -611,15 +443,6 @@ if len(sys.argv) < 2: # no arguments passed, use GUI
     }
     PLAY_BY_LABEL = {v: k for k, v in PLAY_LABELS.items()}
 
-    def _local_available(play):
-        if play == "replay":
-            return False
-        try:
-            resolve_intent(Intent(play, "local", default_boot(play)), modinfos)
-            return True
-        except (KeyError, ValueError):
-            return False
-
     def _pinned_versions(play):
         versions = set()
         if play == "chobby":
@@ -639,18 +462,17 @@ if len(sys.argv) < 2: # no arguments passed, use GUI
         return sorted(versions, reverse=True)
 
     def _local_source_paths(play):
+        # Derived from modinfos (populated once by refresh()) rather than
+        # re-listing <data-dir>/games on every call -- this runs on the
+        # tooltip hover path, and modinfos already holds the scan result.
         if play == "replay":
             return []
-        gamespath = os.path.join(datafolder, "games")
-        if not os.path.isdir(gamespath):
-            return []
         wanted_modtype = "1" if play == "bar" else "5"
+        gamesroot = os.path.join(barinstallpath, datafolder, "games")
         out = []
-        for gamedir in sorted(os.listdir(gamespath)):
-            label = f"[LOCAL] {gamedir}"
-            mi = modinfos.get(label)
-            if mi and str(mi.get("modtype", "")) == wanted_modtype:
-                out.append(os.path.join(gamespath, gamedir))
+        for label, mi in sorted(modinfos.items()):
+            if label.startswith("[LOCAL] ") and str(mi.get("modtype", "")) == wanted_modtype:
+                out.append(os.path.join(gamesroot, label[len("[LOCAL] "):]))
         return out
 
     config_frame = ttk.LabelFrame(root, text='What to launch', style='Section.TLabelframe')
@@ -855,26 +677,19 @@ if len(sys.argv) < 2: # no arguments passed, use GUI
         """Return (opts list, default-local-opt-if-any) for one source axis."""
         opts = ["Latest"]
         local_opt = None
-        if _local_available(play):
-            paths = _local_source_paths(play)
-            tag = paths[0] if paths else "<unknown path>"
-            local_opt = f"Local checkout ({tag})"
+        paths = _local_source_paths(play)
+        if paths:
+            local_opt = f"Local checkout ({paths[0]})"
             opts.append(local_opt)
         for v in _pinned_versions(play):
             opts.append(f"Pinned: {v}")
         return opts, local_opt
 
-    def _populate_chobby_sources():
-        opts, local_opt = _source_options_for("chobby")
-        chobby_source_cb['values'] = opts
-        if selected_chobby_source.get() not in opts:
-            selected_chobby_source.set(local_opt or opts[0])
-
-    def _populate_game_sources():
-        opts, local_opt = _source_options_for("bar")
-        game_source_cb['values'] = opts
-        if selected_game_source.get() not in opts:
-            selected_game_source.set(local_opt or opts[0])
+    def _populate_sources(play, cb, var):
+        opts, local_opt = _source_options_for(play)
+        cb['values'] = opts
+        if var.get() not in opts:
+            var.set(local_opt or opts[0])
 
     def _refresh_states():
         """Grey out the source dropdowns / Map / Boot that don't apply to
@@ -887,23 +702,11 @@ if len(sys.argv) < 2: # no arguments passed, use GUI
         boot_cb.configure(state="readonly" if play in ("chobby", "bar") else "disabled")
         engine_cb.configure(state="readonly" if play != "replay" else "disabled")
 
-    _populate_chobby_sources()
-    _populate_game_sources()
+    _populate_sources("chobby", chobby_source_cb, selected_chobby_source)
+    _populate_sources("bar", game_source_cb, selected_game_source)
     selected_boot.set(default_boot("chobby"))
 
     runcmd = ""
-
-    def _ctx():
-        # Wrap the GUI's existing globals as a Context so we can reuse the
-        # CLI's command builder. build_runcmd is the canonical place that
-        # encodes how (modinfo, engine, map) becomes the engine invocation.
-        return Context(
-            barinstallpath=barinstallpath,
-            datafolder=datafolder,
-            launcher_binary=launcher_binary,
-            engines=engines,
-            modinfos=modinfos,
-        )
 
     def gencmd(event=None):
         global runcmd
@@ -935,7 +738,9 @@ if len(sys.argv) < 2: # no arguments passed, use GUI
         mymap = selected_map.get()
         modopts = modoptionstb.get('1.0', tk.END)
         try:
-            runcmd = build_runcmd(_ctx(), modinfo, myengine, mymap, modopts)
+            # ctx is the Context refresh() built from these same globals;
+            # build_runcmd is the canonical encoder of (modinfo, engine, map).
+            runcmd = build_runcmd(ctx, modinfo, myengine, mymap, modopts)
         except (KeyError, ValueError) as e:
             runcmd = ""
             cmdtext.delete('1.0', tk.END)
@@ -975,6 +780,12 @@ if len(sys.argv) < 2: # no arguments passed, use GUI
 
     def startspring():
         gencmd(None)
+        if not runcmd:
+            # gencmd leaves runcmd empty for Play=Replay and for resolve/build
+            # errors (the reason is already shown in the command panel);
+            # Popen([]) would raise, or run a bare host-exec in a container.
+            print("Nothing to launch; see the Generated command panel.")
+            return
         print('starting spring with', runcmd)
         subprocess.Popen(host_cmd_prefix() + shlex.split(runcmd), close_fds=True)
 

--- a/BAR_Debug_Launcher.py
+++ b/BAR_Debug_Launcher.py
@@ -67,7 +67,7 @@ def find_linux_datadir():
 def find_linux_launcher_binary():
     # Searches for the newest AppImage file in the current directory
     for file in reversed(sorted(os.listdir())):
-        if re.match(r'^Beyond-All-Reason.*\.AppImage$', file):
+        if re.match(r'^beyond[-_]?all[-_]?reason.*\.appimage$', file, re.IGNORECASE):
             return file
     return 'Beyond-All-Reason.AppImage'  # Just something to return...
 
@@ -169,17 +169,22 @@ def parsecache(path):
     menus = {}
     try:
         cachefiles = []
-        for cachedir in os.listdir(path):
-            if os.path.isdir(os.path.join(path,cachedir)):
-                for archivecachefile in os.listdir(os.path.join(path,cachedir)):
+        for item in os.listdir(path):
+            itempath = os.path.join(path, item)
+            if os.path.isdir(itempath):
+                for archivecachefile in os.listdir(itempath):
                     if 'archivecache' in archivecachefile.lower() and archivecachefile.lower().endswith('.lua'):
-                        archivecachefilepath = os.path.join(path,cachedir, archivecachefile)
+                        archivecachefilepath = os.path.join(itempath, archivecachefile)
                         lastmodified = os.path.getmtime(archivecachefilepath)
-                        print ("Found a cache file",cachedir,  archivecachefile, "last modified:", lastmodified)
+                        print ("Found a cache file", item, archivecachefile, "last modified:", lastmodified)
                         cachefiles.append((archivecachefilepath, lastmodified))
+            elif 'archivecache' in item.lower() and item.lower().endswith('.lua'):
+                lastmodified = os.path.getmtime(itempath)
+                print ("Found a cache file (direct)", item, "last modified:", lastmodified)
+                cachefiles.append((itempath, lastmodified))
 
         if len(cachefiles) > 0:
-            cachefiles = sorted(cachefiles, key = lambda x:[1], reverse = True)
+            cachefiles = sorted(cachefiles, key = lambda x: x[1], reverse = True)
             archivecachefilepath = cachefiles[0][0]
             print ("Loading Archive Cache File:", archivecachefilepath)
             archivecachecontents = open(archivecachefilepath).read()
@@ -218,7 +223,6 @@ def refresh():
         if '$VERSION' in menuname:
             modinfos[f'Spring-launcher with {menuname}'] = {'modtype': '0', 'name': menuname}
             modinfos[f'{menuname} (no launcher)'] = {'modtype': '5', 'name': menuname}
-            break
     for gamename in games.keys():
         if '$VERSION' in gamename:
             modinfos[gamename] = {'modtype': '1', 'name': gamename}

--- a/bar_launch/__init__.py
+++ b/bar_launch/__init__.py
@@ -1,0 +1,14 @@
+"""bar_launch — shared core for the Tk GUI and the new CLI."""
+
+from .core import Context, build_context, find_linux_datadir, find_linux_launcher_binary
+from .engine_cmd import build_runcmd, write_start_script, write_dev_lobby_config
+
+__all__ = [
+    "Context",
+    "build_context",
+    "build_runcmd",
+    "find_linux_datadir",
+    "find_linux_launcher_binary",
+    "write_dev_lobby_config",
+    "write_start_script",
+]

--- a/bar_launch/__main__.py
+++ b/bar_launch/__main__.py
@@ -25,8 +25,11 @@ def _resolve_bar_install(args) -> Optional[str]:
     # Windows install layout is <install>\Beyond-All-Reason.exe + <install>\data.
     # The WSL shim passes --data-dir but no --bar-install; derive the install
     # root so launcher boots resolve the .exe instead of argv[0]'s dir.
+    # abspath first: dirname of a relative single-component path ("data")
+    # would otherwise be "", which build_context would take as a literal
+    # install path and resolve everything against cwd with a bare .exe name.
     if args.data_dir and platform.system() == "Windows":
-        return os.path.dirname(os.path.normpath(args.data_dir))
+        return os.path.dirname(os.path.abspath(os.path.normpath(args.data_dir)))
     return None
 
 
@@ -110,6 +113,10 @@ def main(argv: Optional[list[str]] = None) -> int:
             env["BAR_DATA_DIR"] = args.data_dir
         if bar_install:
             env["BAR_INSTALL_PATH"] = bar_install
+        if args.launcher_binary:
+            # The GUI's launcher discovery honors BAR_APPIMAGE_PATH (file or
+            # directory), so --launcher-binary rides along on that.
+            env["BAR_APPIMAGE_PATH"] = args.launcher_binary
         return subprocess.call([sys.executable, gui_script], env=env)
 
     ctx = build_context(

--- a/bar_launch/__main__.py
+++ b/bar_launch/__main__.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 from typing import Optional
 
-from .core import build_context
+from .core import build_context, host_cmd_prefix
 from .engine_cmd import build_runcmd
 from .intents import Intent, default_boot, resolve_intent
 
@@ -126,7 +126,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         return 0
 
     print(f"Launching ({label!r} on engine {engine_version!r}):", cmd)
-    subprocess.Popen(shlex.split(cmd), close_fds=True)
+    subprocess.Popen(host_cmd_prefix() + shlex.split(cmd), close_fds=True)
     return 0
 
 

--- a/bar_launch/__main__.py
+++ b/bar_launch/__main__.py
@@ -24,8 +24,8 @@ def _build_parser() -> argparse.ArgumentParser:
         description="Launch BAR / Recoil for development. Headless or with the existing Tk GUI.",
     )
     p.add_argument("--gui", dest="gui", action="store_true", default=None,
-                   help="force the Tk GUI even if intent flags are present")
-    p.add_argument("--no-gui", dest="gui", action="store_false",
+                   help="force the Tk GUI (default unless --no-gui/--headless or --print-cmd is given)")
+    p.add_argument("--no-gui", "--headless", dest="gui", action="store_false",
                    help="run headless; requires either --play or --game")
     p.add_argument("--data-dir", help="override BAR data dir (default: auto-detect)")
     p.add_argument("--bar-install", help="override BAR install path (default: dirname of argv[0])")
@@ -33,7 +33,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--engine", help="engine version key from the engine cache (e.g. 'recoil_2025.06.19' or 'local-build')")
     p.add_argument("--play", choices=("chobby", "bar", "replay"), help="what to launch")
     p.add_argument("--source", choices=("latest", "local", "pinned"), default="latest",
-                   help="version source: latest test channel, local Devtools checkout, or a pinned cached version")
+                   help="version source: latest test channel, local checkout under <data-dir>/games/, or a pinned cached version")
     p.add_argument("--version", help="cached version, only meaningful with --source pinned")
     p.add_argument("--boot", choices=("launcher", "engine"),
                    help="boot via the AppImage launcher or directly into the engine (defaults: launcher for chobby, engine for bar/replay)")
@@ -77,11 +77,13 @@ def _resolve_modinfo(ctx, args) -> tuple[str, dict]:
 def main(argv: Optional[list[str]] = None) -> int:
     args = _build_parser().parse_args(argv)
 
-    # GUI default: if no intent flags were supplied and --no-gui wasn't asked for, run the GUI.
-    intent_flags_given = any(
-        v is not None for v in (args.play, args.game, args.mapname, args.boot, args.version)
-    ) or args.print_cmd
-    run_gui = args.gui if args.gui is not None else (not intent_flags_given)
+    # GUI is the default. Going headless is an explicit choice -- either
+    # --no-gui/--headless, or --print-cmd which is a pure-CLI affordance and
+    # has no GUI equivalent. Intent flags (--play, --source, etc.) on their
+    # own do NOT skip the GUI; they're irrelevant in GUI mode (the GUI has
+    # its own default-resolution logic) but they shouldn't be a trapdoor that
+    # silently bypasses it. When the user wants headless, they say so.
+    run_gui = args.gui if args.gui is not None else (not args.print_cmd)
 
     if run_gui:
         # The Tk GUI still lives in BAR_Debug_Launcher.py for now; spawn it.

--- a/bar_launch/__main__.py
+++ b/bar_launch/__main__.py
@@ -87,11 +87,17 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     if run_gui:
         # The Tk GUI still lives in BAR_Debug_Launcher.py for now; spawn it.
+        # It has no CLI of its own, so hand it --data-dir/--bar-install via env.
         here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         gui_script = os.path.join(here, "BAR_Debug_Launcher.py")
         if not os.path.exists(gui_script):
             raise SystemExit(f"GUI entry point not found at {gui_script}")
-        return subprocess.call([sys.executable, gui_script])
+        env = dict(os.environ)
+        if args.data_dir:
+            env["BAR_DATA_DIR"] = args.data_dir
+        if args.bar_install:
+            env["BAR_INSTALL_PATH"] = args.bar_install
+        return subprocess.call([sys.executable, gui_script], env=env)
 
     ctx = build_context(
         barinstallpath=args.bar_install,

--- a/bar_launch/__main__.py
+++ b/bar_launch/__main__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import platform
 import shlex
 import subprocess
 import sys
@@ -16,6 +17,17 @@ from typing import Optional
 from .core import build_context
 from .engine_cmd import build_runcmd
 from .intents import Intent, default_boot, resolve_intent
+
+
+def _resolve_bar_install(args) -> Optional[str]:
+    if args.bar_install:
+        return args.bar_install
+    # Windows install layout is <install>\Beyond-All-Reason.exe + <install>\data.
+    # The WSL shim passes --data-dir but no --bar-install; derive the install
+    # root so launcher boots resolve the .exe instead of argv[0]'s dir.
+    if args.data_dir and platform.system() == "Windows":
+        return os.path.dirname(os.path.normpath(args.data_dir))
+    return None
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -84,6 +96,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     # its own default-resolution logic) but they shouldn't be a trapdoor that
     # silently bypasses it. When the user wants headless, they say so.
     run_gui = args.gui if args.gui is not None else (not args.print_cmd)
+    bar_install = _resolve_bar_install(args)
 
     if run_gui:
         # The Tk GUI still lives in BAR_Debug_Launcher.py for now; spawn it.
@@ -95,12 +108,12 @@ def main(argv: Optional[list[str]] = None) -> int:
         env = dict(os.environ)
         if args.data_dir:
             env["BAR_DATA_DIR"] = args.data_dir
-        if args.bar_install:
-            env["BAR_INSTALL_PATH"] = args.bar_install
+        if bar_install:
+            env["BAR_INSTALL_PATH"] = bar_install
         return subprocess.call([sys.executable, gui_script], env=env)
 
     ctx = build_context(
-        barinstallpath=args.bar_install,
+        barinstallpath=bar_install,
         datafolder=args.data_dir,
         launcher_binary=args.launcher_binary,
     )

--- a/bar_launch/__main__.py
+++ b/bar_launch/__main__.py
@@ -1,0 +1,113 @@
+"""CLI entry point: `python -m bar_launch ...`.
+
+Resolves an intent (or explicit --game label) to an engine command and either
+prints it (--print-cmd) or executes it. The Tk GUI is launched when no
+intent-style flags are provided and --no-gui isn't set.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from typing import Optional
+
+from .core import build_context
+from .engine_cmd import build_runcmd
+from .intents import Intent, default_boot, resolve_intent
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="bar_launch",
+        description="Launch BAR / Recoil for development. Headless or with the existing Tk GUI.",
+    )
+    p.add_argument("--gui", dest="gui", action="store_true", default=None,
+                   help="force the Tk GUI even if intent flags are present")
+    p.add_argument("--no-gui", dest="gui", action="store_false",
+                   help="run headless; requires either --play or --game")
+    p.add_argument("--data-dir", help="override BAR data dir (default: auto-detect)")
+    p.add_argument("--bar-install", help="override BAR install path (default: dirname of argv[0])")
+    p.add_argument("--launcher-binary", help="override launcher (AppImage / .exe) path")
+    p.add_argument("--engine", help="engine version key from the engine cache (e.g. 'recoil_2025.06.19' or 'local-build')")
+    p.add_argument("--play", choices=("chobby", "bar", "replay"), help="what to launch")
+    p.add_argument("--source", choices=("latest", "local", "pinned"), default="latest",
+                   help="version source: latest test channel, local Devtools checkout, or a pinned cached version")
+    p.add_argument("--version", help="cached version, only meaningful with --source pinned")
+    p.add_argument("--boot", choices=("launcher", "engine"),
+                   help="boot via the AppImage launcher or directly into the engine (defaults: launcher for chobby, engine for bar/replay)")
+    p.add_argument("--map", dest="mapname", help="map name (only with --play bar)")
+    p.add_argument("--modopts", default="", help="additional modoptions (only with --play bar)")
+    p.add_argument("--game", help="legacy: pick by exact modinfos label (skips --play/--source resolution)")
+    p.add_argument("--print-cmd", action="store_true", help="resolve and print the engine command, don't execute")
+    return p
+
+
+def _resolve_engine(ctx, requested: Optional[str]) -> str:
+    if requested:
+        # Allow exact match or trailing-substring match (e.g. 'local-build' for 'recoil_local-build').
+        if requested in ctx.engines:
+            return requested
+        for k in ctx.engines:
+            if requested in k:
+                return k
+        raise SystemExit(f"engine {requested!r} not found in {sorted(ctx.engines.keys())}")
+    if not ctx.engines or list(ctx.engines.keys()) == ["NO ENGINES FOUND!"]:
+        raise SystemExit("no engines installed in the BAR data dir")
+    return sorted(ctx.engines.keys())[-1]
+
+
+def _resolve_modinfo(ctx, args) -> tuple[str, dict]:
+    if args.game is not None:
+        if args.game not in ctx.modinfos:
+            raise SystemExit(f"--game {args.game!r} not found; valid: {sorted(ctx.modinfos.keys())}")
+        return args.game, ctx.modinfos[args.game]
+    if args.play is None:
+        raise SystemExit("headless mode requires --play (or --game for legacy label-based selection)")
+    intent = Intent(
+        play=args.play,
+        source=args.source,
+        boot=args.boot or default_boot(args.play),
+        version=args.version,
+    )
+    return resolve_intent(intent, ctx.modinfos)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    # GUI default: if no intent flags were supplied and --no-gui wasn't asked for, run the GUI.
+    intent_flags_given = any(
+        v is not None for v in (args.play, args.game, args.mapname, args.boot, args.version)
+    ) or args.print_cmd
+    run_gui = args.gui if args.gui is not None else (not intent_flags_given)
+
+    if run_gui:
+        # The Tk GUI still lives in BAR_Debug_Launcher.py for now; spawn it.
+        here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        gui_script = os.path.join(here, "BAR_Debug_Launcher.py")
+        if not os.path.exists(gui_script):
+            raise SystemExit(f"GUI entry point not found at {gui_script}")
+        return subprocess.call([sys.executable, gui_script])
+
+    ctx = build_context(
+        barinstallpath=args.bar_install,
+        datafolder=args.data_dir,
+        launcher_binary=args.launcher_binary,
+    )
+    engine_version = _resolve_engine(ctx, args.engine)
+    label, modinfo = _resolve_modinfo(ctx, args)
+    cmd = build_runcmd(ctx, modinfo, engine_version, args.mapname, args.modopts)
+
+    if args.print_cmd:
+        print(cmd)
+        return 0
+
+    print(f"Launching ({label!r} on engine {engine_version!r}):", cmd)
+    subprocess.Popen(shlex.split(cmd), close_fds=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bar_launch/core.py
+++ b/bar_launch/core.py
@@ -1,0 +1,257 @@
+"""Discovery and platform glue for the launcher.
+
+No side effects on import: callers build a Context via build_context().
+"""
+from __future__ import annotations
+
+import os
+import platform
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import Optional
+
+from slpp import slpp
+
+
+# ---------------------------------------------------------------------------
+# Platform-specific constants.
+# ---------------------------------------------------------------------------
+
+if platform.system() == "Windows":
+    engine_binary = "spring.exe"
+    prd_binary = "pr-downloader.exe"
+    default_datafolder = "data"
+    default_launcher_binary = "Beyond-All-Reason.exe"
+    launcher_binary_display = "Beyond-All-Reason.exe"
+    engine_download_baseurl = "https://github.com/beyond-all-reason/spring/releases/download/spring_bar_%7BBAR105%7D{enginebaseversion}/spring_bar_.BAR105.{enginebaseversion}_windows-64-minimal-portable.7z"
+    engine_download_baseurl_new = "https://github.com/beyond-all-reason/spring/releases/download/{enginebaseversion}/spring_bar_.{releaseID}.{enginebaseversion}_windows-64-minimal-portable.7z"
+    engine_download_baseurl_newest = "https://github.com/beyond-all-reason/RecoilEngine/releases/download/{enginebaseversion}/recoil_{enginebaseversion}_amd64-windows.7z"
+elif platform.system() == "Linux":
+    engine_binary = "spring"
+    prd_binary = "pr-downloader"
+    default_datafolder = None  # resolved per-Context via find_linux_datadir()
+    default_launcher_binary = None  # resolved per-Context via find_linux_launcher_binary()
+    launcher_binary_display = "Beyond-All-Reason AppImage"
+    engine_download_baseurl = "https://github.com/beyond-all-reason/spring/releases/download/spring_bar_%7BBAR105%7D{enginebaseversion}/spring_bar_.BAR105.{enginebaseversion}_linux-64-minimal-portable.7z"
+    engine_download_baseurl_new = "https://github.com/beyond-all-reason/spring/releases/download/{enginebaseversion}/spring_bar_.{releaseID}.{enginebaseversion}_linux-64-minimal-portable.7z"
+    engine_download_baseurl_newest = "https://github.com/beyond-all-reason/RecoilEngine/releases/download/{enginebaseversion}/recoil_{enginebaseversion}_amd64-linux.7z"
+else:
+    raise Exception("Unsupported platform")
+
+
+# ---------------------------------------------------------------------------
+# Linux discovery helpers.
+# ---------------------------------------------------------------------------
+
+def find_linux_datadir() -> str:
+    try:
+        documents = subprocess.check_output(
+            ["xdg-user-dir", "DOCUMENTS"], encoding="utf-8"
+        ).strip()
+    except Exception:
+        documents = os.path.expanduser("~")
+    if os.path.exists(os.path.join(documents, "Beyond All Reason")):
+        return os.path.join(documents, "Beyond All Reason")
+
+    state_home = os.getenv(
+        "XDG_STATE_HOME",
+        default=os.path.join(os.path.expanduser("~"), ".local", "state"),
+    )
+    return os.path.join(state_home, "Beyond All Reason")
+
+
+# Order:
+#   1. $BAR_APPIMAGE_PATH if set and pointing at an existing file
+#   2. Scan cwd for an AppImage matching the case-insensitive regex
+#   3. Fallback string so the GUI still has *something* to display
+_APPIMAGE_RE = re.compile(r"^beyond[-_]?all[-_]?reason.*\.appimage$", re.IGNORECASE)
+
+
+def find_linux_launcher_binary(barinstallpath: Optional[str] = None) -> str:
+    env_path = os.environ.get("BAR_APPIMAGE_PATH")
+    if env_path:
+        expanded = os.path.expanduser(env_path)
+        if os.path.isfile(expanded):
+            return expanded
+
+    candidates = [os.getcwd()]
+    if barinstallpath:
+        candidates.append(barinstallpath)
+    for d in candidates:
+        if not os.path.isdir(d):
+            continue
+        for name in reversed(sorted(os.listdir(d))):
+            if _APPIMAGE_RE.match(name):
+                return os.path.join(d, name)
+    return "Beyond-All-Reason.AppImage"
+
+
+# ---------------------------------------------------------------------------
+# Engine + cache discovery (returns dicts, no global state).
+# ---------------------------------------------------------------------------
+
+def findengines(enginefolder: str) -> tuple[dict[str, str], dict]:
+    engines: dict[str, str] = {}
+    enginedirs: dict = {}
+    if os.path.exists(enginefolder):
+        for engineversion in os.listdir(enginefolder):
+            enginedir = os.path.join(enginefolder, engineversion)
+            enginepath = os.path.join(enginedir, engine_binary)
+            if os.path.isdir(enginedir) and os.path.exists(enginepath):
+                print(f"Found engine version {engineversion} in path: {enginepath}")
+                engines[engineversion] = enginepath
+    if not engines:
+        engines["NO ENGINES FOUND!"] = "NO ENGINES FOUND!"
+    return engines, enginedirs
+
+
+def parsecache(path: str) -> tuple[dict[str, str], dict[str, str], dict[str, str]]:
+    maps: dict[str, str] = {}
+    games: dict[str, str] = {}
+    menus: dict[str, str] = {}
+    try:
+        cachefiles: list[tuple[str, float]] = []
+        if not os.path.isdir(path):
+            return maps, games, menus
+        for item in os.listdir(path):
+            itempath = os.path.join(path, item)
+            if os.path.isdir(itempath):
+                for archivecachefile in os.listdir(itempath):
+                    if (
+                        "archivecache" in archivecachefile.lower()
+                        and archivecachefile.lower().endswith(".lua")
+                    ):
+                        archivecachefilepath = os.path.join(itempath, archivecachefile)
+                        lastmodified = os.path.getmtime(archivecachefilepath)
+                        print("Found a cache file", item, archivecachefile, "last modified:", lastmodified)
+                        cachefiles.append((archivecachefilepath, lastmodified))
+            elif "archivecache" in item.lower() and item.lower().endswith(".lua"):
+                lastmodified = os.path.getmtime(itempath)
+                print("Found a cache file (direct)", item, "last modified:", lastmodified)
+                cachefiles.append((itempath, lastmodified))
+
+        if cachefiles:
+            cachefiles.sort(key=lambda x: x[1], reverse=True)
+            archivecachefilepath = cachefiles[0][0]
+            print("Loading Archive Cache File:", archivecachefilepath)
+            archivecachecontents = open(archivecachefilepath).read()
+            archivetable = "{" + archivecachecontents.partition("{")[2].rpartition("}")[0] + "}"
+            archivetable = slpp.decode(archivetable)
+            for archive in archivetable["archives"]:
+                if "archivedata" in archive and "modtype" in archive["archivedata"]:
+                    archivedata = archive["archivedata"]
+                    modtype = archivedata["modtype"]
+                    if modtype == 3:
+                        maps[archivedata["name"]] = archive["name"]
+                    elif modtype == 5:
+                        menus[archivedata["name"]] = archive["name"]
+                    elif modtype == 1:
+                        games[archivedata["name"]] = archive["name"]
+            print(f"Found {len(maps)} maps, {len(games)} games, {len(menus)} menus")
+    except Exception as e:
+        print("parsecache error, dont code blind!", e)
+    return maps, games, menus
+
+
+def parsemodinfo(path: str) -> Optional[dict]:
+    try:
+        with open(path, "r") as f:
+            contents = f.read()
+        table_str = "{" + contents.partition("{")[2].rpartition("}")[0] + "}"
+        return slpp.decode(table_str)
+    except Exception as e:
+        print(f"Error parsing {path}: {e}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Context: the resolved state used by both the GUI and the CLI.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Context:
+    barinstallpath: str
+    datafolder: str
+    launcher_binary: str
+    engines: dict[str, str] = field(default_factory=dict)
+    enginedirs: dict = field(default_factory=dict)
+    maps: dict[str, str] = field(default_factory=dict)
+    games: dict[str, str] = field(default_factory=dict)
+    menus: dict[str, str] = field(default_factory=dict)
+    modinfos: dict[str, dict] = field(default_factory=dict)
+
+
+def build_context(
+    barinstallpath: Optional[str] = None,
+    datafolder: Optional[str] = None,
+    launcher_binary: Optional[str] = None,
+) -> Context:
+    """Build a fresh Context by scanning the BAR install for cache, engines, and games."""
+    if barinstallpath is None:
+        barinstallpath = os.path.abspath(os.path.dirname(sys.argv[0]))
+
+    if datafolder is None:
+        if platform.system() == "Windows":
+            datafolder = "data"
+        else:
+            datafolder = find_linux_datadir()
+
+    if launcher_binary is None:
+        if platform.system() == "Windows":
+            launcher_binary = "Beyond-All-Reason.exe"
+        else:
+            launcher_binary = find_linux_launcher_binary(barinstallpath)
+
+    ctx = Context(
+        barinstallpath=barinstallpath,
+        datafolder=datafolder,
+        launcher_binary=launcher_binary,
+    )
+
+    ctx.maps, ctx.games, ctx.menus = parsecache(os.path.join(barinstallpath, datafolder, "cache"))
+    ctx.engines, ctx.enginedirs = findengines(os.path.join(barinstallpath, datafolder, "engine"))
+
+    modinfos: dict[str, dict] = {}
+    modinfos["Spring-launcher with rapid://byar-chobby:test"] = {"modtype": "0", "name": "rapid://byar-chobby:test"}
+    modinfos["Latest BYAR Chobby Lobby: rapid://byar-chobby:test"] = {"name": "rapid://byar-chobby:test", "version": "", "modtype": "5"}
+    modinfos["Latest BAR Game: rapid://byar:test"] = {"name": "rapid://byar:test", "version": "", "modtype": "1"}
+
+    for menuname in ctx.menus.keys():
+        if "$VERSION" in menuname:
+            modinfos[f"Spring-launcher with {menuname}"] = {"modtype": "0", "name": menuname}
+            modinfos[f"{menuname} (no launcher)"] = {"modtype": "5", "name": menuname}
+    for gamename in ctx.games.keys():
+        if "$VERSION" in gamename:
+            modinfos[gamename] = {"modtype": "1", "name": gamename}
+
+    gamespath = os.path.join(datafolder, "games")
+    if os.path.exists(gamespath):
+        for gamedir in os.listdir(gamespath):
+            gamepath = os.path.join(gamespath, gamedir)
+            if not os.path.isdir(gamepath):
+                continue
+            modinfopath = os.path.join(gamepath, "modinfo.lua")
+            if not os.path.exists(modinfopath):
+                continue
+            modinfo = parsemodinfo(modinfopath)
+            if not (modinfo and "name" in modinfo):
+                continue
+            base_name = modinfo["name"]
+            version = modinfo.get("version", "")
+            if version == "$VERSION" and "$VERSION" not in base_name:
+                name = f"{base_name} $VERSION"
+            else:
+                name = base_name
+            mtype = str(modinfo.get("modtype", "1"))
+            display_name = f"[LOCAL] {gamedir}"
+            modinfos[display_name] = {"modtype": mtype, "name": name}
+            if mtype == "5":
+                modinfos[f"[LOCAL] Spring-launcher with {gamedir}"] = {"modtype": "0", "name": name}
+
+    ctx.modinfos = modinfos
+    for k, v in modinfos.items():
+        print(k, v)
+
+    return ctx

--- a/bar_launch/core.py
+++ b/bar_launch/core.py
@@ -79,7 +79,7 @@ def find_linux_datadir() -> str:
 
 # Order:
 #   1. $BAR_APPIMAGE_PATH if set and pointing at an existing file
-#   2. Scan cwd for an AppImage matching the case-insensitive regex
+#   2. Scan barinstallpath, then cwd, for an AppImage matching the regex
 #   3. Fallback string so the GUI still has *something* to display
 _APPIMAGE_RE = re.compile(r"^beyond[-_]?all[-_]?reason.*\.appimage$", re.IGNORECASE)
 
@@ -91,8 +91,10 @@ def find_linux_launcher_binary(barinstallpath: Optional[str] = None) -> str:
     #      this lets users set BAR_APPIMAGE_PATH=~/Applications/ or =~/apps/BAR/
     #      without having to know the AppImage's exact filename, which churns
     #      with each release.
-    #   3. cwd / barinstallpath scan, for the standalone "drop the launcher
-    #      next to the AppImage and double-click" workflow.
+    #   3. barinstallpath / cwd scan, for the standalone "drop the launcher
+    #      next to the AppImage and double-click" workflow. The explicitly
+    #      configured install path outranks cwd so a stray AppImage in
+    #      whatever directory the CLI happens to run from can't shadow it.
     candidates = []
     env_path = os.environ.get("BAR_APPIMAGE_PATH")
     if env_path:
@@ -102,9 +104,9 @@ def find_linux_launcher_binary(barinstallpath: Optional[str] = None) -> str:
         if os.path.isdir(expanded):
             candidates.append(expanded)
 
-    candidates.append(os.getcwd())
     if barinstallpath:
         candidates.append(barinstallpath)
+    candidates.append(os.getcwd())
     for d in candidates:
         if not os.path.isdir(d):
             continue
@@ -118,9 +120,8 @@ def find_linux_launcher_binary(barinstallpath: Optional[str] = None) -> str:
 # Engine + cache discovery (returns dicts, no global state).
 # ---------------------------------------------------------------------------
 
-def findengines(enginefolder: str) -> tuple[dict[str, str], dict]:
+def findengines(enginefolder: str) -> dict[str, str]:
     engines: dict[str, str] = {}
-    enginedirs: dict = {}
     if os.path.exists(enginefolder):
         for engineversion in os.listdir(enginefolder):
             enginedir = os.path.join(enginefolder, engineversion)
@@ -130,7 +131,7 @@ def findengines(enginefolder: str) -> tuple[dict[str, str], dict]:
                 engines[engineversion] = enginepath
     if not engines:
         engines["NO ENGINES FOUND!"] = "NO ENGINES FOUND!"
-    return engines, enginedirs
+    return engines
 
 
 def parsecache(path: str) -> tuple[dict[str, str], dict[str, str], dict[str, str]]:
@@ -202,7 +203,6 @@ class Context:
     datafolder: str
     launcher_binary: str
     engines: dict[str, str] = field(default_factory=dict)
-    enginedirs: dict = field(default_factory=dict)
     maps: dict[str, str] = field(default_factory=dict)
     games: dict[str, str] = field(default_factory=dict)
     menus: dict[str, str] = field(default_factory=dict)
@@ -219,16 +219,10 @@ def build_context(
         barinstallpath = os.path.abspath(os.path.dirname(sys.argv[0]))
 
     if datafolder is None:
-        if platform.system() == "Windows":
-            datafolder = "data"
-        else:
-            datafolder = find_linux_datadir()
+        datafolder = default_datafolder or find_linux_datadir()
 
     if launcher_binary is None:
-        if platform.system() == "Windows":
-            launcher_binary = "Beyond-All-Reason.exe"
-        else:
-            launcher_binary = find_linux_launcher_binary(barinstallpath)
+        launcher_binary = default_launcher_binary or find_linux_launcher_binary(barinstallpath)
 
     ctx = Context(
         barinstallpath=barinstallpath,
@@ -237,7 +231,7 @@ def build_context(
     )
 
     ctx.maps, ctx.games, ctx.menus = parsecache(os.path.join(barinstallpath, datafolder, "cache"))
-    ctx.engines, ctx.enginedirs = findengines(os.path.join(barinstallpath, datafolder, "engine"))
+    ctx.engines = findengines(os.path.join(barinstallpath, datafolder, "engine"))
 
     modinfos: dict[str, dict] = {}
     modinfos["Spring-launcher with rapid://byar-chobby:test"] = {"modtype": "0", "name": "rapid://byar-chobby:test"}
@@ -252,7 +246,7 @@ def build_context(
         if "$VERSION" in gamename:
             modinfos[gamename] = {"modtype": "1", "name": gamename}
 
-    gamespath = os.path.join(datafolder, "games")
+    gamespath = os.path.join(barinstallpath, datafolder, "games")
     if os.path.exists(gamespath):
         for gamedir in os.listdir(gamespath):
             gamepath = os.path.join(gamespath, gamedir)

--- a/bar_launch/core.py
+++ b/bar_launch/core.py
@@ -70,13 +70,24 @@ _APPIMAGE_RE = re.compile(r"^beyond[-_]?all[-_]?reason.*\.appimage$", re.IGNOREC
 
 
 def find_linux_launcher_binary(barinstallpath: Optional[str] = None) -> str:
+    # Resolution order:
+    #   1. $BAR_APPIMAGE_PATH if it points at an existing AppImage *file*.
+    #   2. $BAR_APPIMAGE_PATH if it points at a *directory* containing one --
+    #      this lets users set BAR_APPIMAGE_PATH=~/Applications/ or =~/apps/BAR/
+    #      without having to know the AppImage's exact filename, which churns
+    #      with each release.
+    #   3. cwd / barinstallpath scan, for the standalone "drop the launcher
+    #      next to the AppImage and double-click" workflow.
+    candidates = []
     env_path = os.environ.get("BAR_APPIMAGE_PATH")
     if env_path:
         expanded = os.path.expanduser(env_path)
         if os.path.isfile(expanded):
             return expanded
+        if os.path.isdir(expanded):
+            candidates.append(expanded)
 
-    candidates = [os.getcwd()]
+    candidates.append(os.getcwd())
     if barinstallpath:
         candidates.append(barinstallpath)
     for d in candidates:

--- a/bar_launch/core.py
+++ b/bar_launch/core.py
@@ -7,12 +7,27 @@ from __future__ import annotations
 import os
 import platform
 import re
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass, field
 from typing import Optional
 
 from slpp import slpp
+
+
+def host_cmd_prefix():
+    """Prefix to run a host binary from inside a distrobox/toolbox container.
+
+    The engine/AppImage needs host-side FUSE + GPU userspace, so when we're
+    containerized we run it on the host. Empty list when running natively.
+    """
+    if os.path.exists("/run/.containerenv") or os.environ.get("CONTAINER_ID"):
+        for tool in ("distrobox-host-exec", "host-spawn"):
+            path = shutil.which(tool)
+            if path:
+                return [path]
+    return []
 
 
 # ---------------------------------------------------------------------------

--- a/bar_launch/engine_cmd.py
+++ b/bar_launch/engine_cmd.py
@@ -1,0 +1,120 @@
+"""Pure command-string construction. Shared by GUI gencmd and CLI."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional
+
+from .core import Context
+
+SCRIPT_BASE = """
+[game]
+{
+    [allyteam1]
+    {
+        numallies=0;
+    }
+    [team1]
+    {
+        teamleader=0;
+        allyteam=1;
+    }
+    [ai0]
+    {
+        shortname=NullAI;
+        name=NullAI;
+        version=0.1;
+        team=1;
+        host=0;
+    }
+    [modoptions]
+    {
+        %s
+    }
+    [allyteam0]
+    {
+        numallies=0;
+    }
+    [team0]
+    {
+        teamleader=0;
+        allyteam=0;
+    }
+    [player0]
+    {
+        team=0;
+        name=DebugLauncher;
+    }
+    mapname=%s;
+    myplayername=DebugLauncher;
+    ishost=1;
+    gametype=%s;
+    nohelperais=0;
+}"""
+
+
+def write_start_script(modopts: str, mapname: str, gamename: str, path: str = "bar_debug_launcher_script.txt") -> str:
+    """Write the engine start script. Returns the path written."""
+    script = SCRIPT_BASE % (modopts, mapname, gamename)
+    with open(path, "w") as f:
+        f.write(script)
+    print("Generated script:", script)
+    return path
+
+
+def write_dev_lobby_config(
+    engine_version: str,
+    mod_name: str,
+    path: str = "bar_debug_launcher_config.json",
+) -> str:
+    """Write the spring-launcher dev-lobby config. Returns the path written."""
+    config = {
+        "title": "Beyond All Reason",
+        "setups": [
+            {
+                "package": {"id": "dev-lobby", "display": "Dev Lobby"},
+                "downloads": {"engines": [engine_version]},
+                "no_start_script": True,
+                "no_downloads": True,
+                "auto_start": True,
+                "launch": {"start_args": ["--menu", mod_name]},
+            }
+        ],
+    }
+    with open(path, "w") as f:
+        json.dump(config, f, indent=4)
+    return path
+
+
+def build_runcmd(
+    ctx: Context,
+    modinfo: dict,
+    engine_version: str,
+    mapname: Optional[str] = None,
+    modopts: str = "",
+    script_path: str = "bar_debug_launcher_script.txt",
+    config_path: str = "bar_debug_launcher_config.json",
+) -> str:
+    """Build the engine command string for a given (modinfo, engine, map) triple.
+
+    `engine_version` is a key into ctx.engines (e.g. "recoil_2025.06.19" or
+    "105.1.1-941-g941148f bar"). Returns the shell command string; the caller
+    is responsible for executing or printing it.
+    """
+    write_dir = os.path.join(ctx.barinstallpath, ctx.datafolder)
+    enginepath = ctx.engines.get(engine_version)
+    if enginepath is None:
+        raise KeyError(f"engine {engine_version!r} not in ctx.engines")
+
+    mtype = modinfo["modtype"]
+    if mtype == "5":
+        return f'"{enginepath}"  --isolation --write-dir "{write_dir}" --menu "{modinfo["name"]}"'
+    if mtype == "1":
+        if mapname and mapname != "Ill choose my own once ingame":
+            write_start_script(modopts, mapname, modinfo["name"], script_path)
+            return f'"{enginepath}"  --isolation --write-dir "{write_dir}" {script_path}'
+        return f'"{enginepath}"  --isolation --write-dir "{write_dir}"'
+    if mtype == "0":
+        write_dev_lobby_config(engine_version, modinfo["name"], config_path)
+        return f'"{os.path.join(ctx.barinstallpath, ctx.launcher_binary)}" -c "{os.path.join(ctx.barinstallpath, config_path)}"'
+    raise ValueError(f"unknown modtype {mtype!r}")

--- a/bar_launch/engine_cmd.py
+++ b/bar_launch/engine_cmd.py
@@ -106,15 +106,25 @@ def build_runcmd(
     if enginepath is None:
         raise KeyError(f"engine {engine_version!r} not in ctx.engines")
 
+    # Anchor relative side-effect files under barinstallpath so the file we
+    # write is the same file the command references. (The GUI chdirs to
+    # barinstallpath, so this is a no-op there; the headless CLI never chdirs,
+    # and previously wrote the config to cwd while pointing the launcher at a
+    # nonexistent/stale barinstallpath copy.)
+    if not os.path.isabs(script_path):
+        script_path = os.path.join(ctx.barinstallpath, script_path)
+    if not os.path.isabs(config_path):
+        config_path = os.path.join(ctx.barinstallpath, config_path)
+
     mtype = modinfo["modtype"]
     if mtype == "5":
         return f'"{enginepath}"  --isolation --write-dir "{write_dir}" --menu "{modinfo["name"]}"'
     if mtype == "1":
         if mapname and mapname != "Ill choose my own once ingame":
             write_start_script(modopts, mapname, modinfo["name"], script_path)
-            return f'"{enginepath}"  --isolation --write-dir "{write_dir}" {script_path}'
+            return f'"{enginepath}"  --isolation --write-dir "{write_dir}" "{script_path}"'
         return f'"{enginepath}"  --isolation --write-dir "{write_dir}"'
     if mtype == "0":
         write_dev_lobby_config(engine_version, modinfo["name"], config_path)
-        return f'"{os.path.join(ctx.barinstallpath, ctx.launcher_binary)}" -c "{os.path.join(ctx.barinstallpath, config_path)}"'
+        return f'"{os.path.join(ctx.barinstallpath, ctx.launcher_binary)}" -c "{config_path}"'
     raise ValueError(f"unknown modtype {mtype!r}")

--- a/bar_launch/intents.py
+++ b/bar_launch/intents.py
@@ -14,6 +14,7 @@ the launcher already understands. Tests live in tests/test_intents.py.
 """
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Optional
 
@@ -75,31 +76,42 @@ def resolve_intent(intent: Intent, modinfos: dict[str, dict]) -> tuple[str, dict
             raise KeyError(f"expected {label!r} in modinfos but it's missing")
         return label, modinfos[label]
 
-    # Local -> entries discovered by the [LOCAL] scan in build_context.
+    # Local -> entries discovered by the [LOCAL] scan in build_context. The
+    # scan labels checkouts f"[LOCAL] {gamedir}" for *any* directory name, so
+    # match on the [LOCAL] tag + modtype rather than hardcoded checkout names:
+    #   modtype 1 = game, modtype 5 = chobby engine-direct, and for every
+    #   modtype-5 checkout the scan also adds a paired modtype-0
+    #   "[LOCAL] Spring-launcher with ..." entry for launcher boots.
     if intent.source == "local":
         if intent.play == "chobby":
-            # The local-games scan tags chobby-style entries (modtype 5).
             wanted_modtype = "5" if intent.boot == "engine" else "0"
-            prefix_engine = "[LOCAL] BYAR-Chobby"
-            prefix_launcher = "[LOCAL] Spring-launcher with BYAR-Chobby"
         else:  # bar
             wanted_modtype = "1"
-            prefix_engine = "[LOCAL] Beyond-All-Reason"
-            prefix_launcher = None
-        prefix = prefix_launcher if intent.boot == "launcher" and prefix_launcher else prefix_engine
         for label, mi in modinfos.items():
-            if label.startswith(prefix) and str(mi.get("modtype", "")) == wanted_modtype:
+            if label.startswith("[LOCAL]") and str(mi.get("modtype", "")) == wanted_modtype:
                 return label, mi
         raise KeyError(
             f"no [LOCAL] entry matches play={intent.play} boot={intent.boot}; "
             f"is a checkout linked into <data-dir>/games/?"
         )
 
-    # Pinned -> match $VERSION-tagged entries by substring of intent.version.
+    # Pinned -> match $VERSION-tagged entries by intent.version. Prefer an
+    # exact whitespace-delimited token match so e.g. version "2025.04.1" can't
+    # silently resolve to "... 2025.04.10 $VERSION"; fall back to substring so
+    # partial pins like "2025.04" keep working.
     assert intent.source == "pinned" and intent.version
     needle = intent.version
     wanted_modtype = "1" if intent.play == "bar" else ("0" if intent.boot == "launcher" else "5")
+    token_re = re.compile(rf"(?<!\S){re.escape(needle)}(?!\S)")
+    exact_match = None
+    substring_match = None
     for label, mi in modinfos.items():
-        if needle in label and str(mi.get("modtype", "")) == wanted_modtype:
-            return label, mi
+        if str(mi.get("modtype", "")) != wanted_modtype or needle not in label:
+            continue
+        if exact_match is None and token_re.search(label):
+            exact_match = (label, mi)
+        if substring_match is None:
+            substring_match = (label, mi)
+    if exact_match or substring_match:
+        return exact_match or substring_match
     raise KeyError(f"no entry containing {needle!r} found for play={intent.play} boot={intent.boot}")

--- a/bar_launch/intents.py
+++ b/bar_launch/intents.py
@@ -1,0 +1,105 @@
+"""Intent translation: human-meaningful (play, source, boot) -> raw modinfo.
+
+The launcher's existing dropdown labels conflate three orthogonal axes into
+one string:
+
+    1. What you want to play: chobby (lobby/menu) vs bar (game) vs replay
+    2. Which version: latest test channel, local checkout, or a pinned cached
+       version
+    3. How it boots: through the AppImage launcher (modtype 0) or straight
+       into the engine (modtype 5 for menus, modtype 1 for games)
+
+This module takes a triple and returns a (label, modinfo) pair the rest of
+the launcher already understands. Tests live in tests/test_intents.py.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+PLAY_CHOICES = ("chobby", "bar", "replay")
+SOURCE_CHOICES = ("latest", "local", "pinned")
+BOOT_CHOICES = ("launcher", "engine")
+
+
+@dataclass
+class Intent:
+    play: str            # "chobby" | "bar" | "replay"
+    source: str          # "latest" | "local" | "pinned"
+    boot: str            # "launcher" | "engine"
+    version: Optional[str] = None  # required iff source == "pinned"
+
+
+def default_boot(play: str) -> str:
+    """Default boot mode for a given --play value.
+
+    Chobby boots via the AppImage launcher (modtype 0) so the launcher can
+    handle splash + downloads. BAR and replays boot the engine directly so we
+    don't pay launcher overhead.
+    """
+    if play == "chobby":
+        return "launcher"
+    return "engine"
+
+
+def resolve_intent(intent: Intent, modinfos: dict[str, dict]) -> tuple[str, dict]:
+    """Pick the right modinfos entry for an intent.
+
+    Returns (label, modinfo) where label is the modinfos key (useful for
+    debugging / --print-cmd) and modinfo is the dict the engine_cmd module
+    expects.
+    """
+    if intent.play not in PLAY_CHOICES:
+        raise ValueError(f"unknown play={intent.play!r}, expected one of {PLAY_CHOICES}")
+    if intent.source not in SOURCE_CHOICES:
+        raise ValueError(f"unknown source={intent.source!r}, expected one of {SOURCE_CHOICES}")
+    if intent.boot not in BOOT_CHOICES:
+        raise ValueError(f"unknown boot={intent.boot!r}, expected one of {BOOT_CHOICES}")
+    if intent.source == "pinned" and not intent.version:
+        raise ValueError("source=pinned requires version=...")
+    if intent.play == "replay":
+        raise ValueError("replay intents go through try_start_replay, not resolve_intent")
+
+    # Latest -> the canonical rapid:// keys that build_context always inserts.
+    if intent.source == "latest":
+        if intent.play == "chobby":
+            label = (
+                "Spring-launcher with rapid://byar-chobby:test"
+                if intent.boot == "launcher"
+                else "Latest BYAR Chobby Lobby: rapid://byar-chobby:test"
+            )
+        else:  # bar
+            label = "Latest BAR Game: rapid://byar:test"
+        if label not in modinfos:
+            raise KeyError(f"expected {label!r} in modinfos but it's missing")
+        return label, modinfos[label]
+
+    # Local -> entries discovered by the [LOCAL] scan in build_context.
+    if intent.source == "local":
+        if intent.play == "chobby":
+            # The local-games scan tags chobby-style entries (modtype 5).
+            wanted_modtype = "5" if intent.boot == "engine" else "0"
+            prefix_engine = "[LOCAL] BYAR-Chobby"
+            prefix_launcher = "[LOCAL] Spring-launcher with BYAR-Chobby"
+        else:  # bar
+            wanted_modtype = "1"
+            prefix_engine = "[LOCAL] Beyond-All-Reason"
+            prefix_launcher = None
+        prefix = prefix_launcher if intent.boot == "launcher" and prefix_launcher else prefix_engine
+        for label, mi in modinfos.items():
+            if label.startswith(prefix) and str(mi.get("modtype", "")) == wanted_modtype:
+                return label, mi
+        raise KeyError(
+            f"no [LOCAL] entry matches play={intent.play} boot={intent.boot}; "
+            f"did you run `just link::create`?"
+        )
+
+    # Pinned -> match $VERSION-tagged entries by substring of intent.version.
+    assert intent.source == "pinned" and intent.version
+    needle = intent.version
+    wanted_modtype = "1" if intent.play == "bar" else ("0" if intent.boot == "launcher" else "5")
+    for label, mi in modinfos.items():
+        if needle in label and str(mi.get("modtype", "")) == wanted_modtype:
+            return label, mi
+    raise KeyError(f"no entry containing {needle!r} found for play={intent.play} boot={intent.boot}")

--- a/bar_launch/intents.py
+++ b/bar_launch/intents.py
@@ -92,7 +92,7 @@ def resolve_intent(intent: Intent, modinfos: dict[str, dict]) -> tuple[str, dict
                 return label, mi
         raise KeyError(
             f"no [LOCAL] entry matches play={intent.play} boot={intent.boot}; "
-            f"did you run `just link::create`?"
+            f"is a checkout linked into <data-dir>/games/?"
         )
 
     # Pinned -> match $VERSION-tagged entries by substring of intent.version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bar_launch"
+version = "0.1.0"
+description = "BAR / Recoil dev launcher: shared core, CLI, and Tk GUI"
+requires-python = ">=3.10"
+dependencies = [
+    "py7zr",
+    "requests",
+    "six",
+]
+
+[project.scripts]
+bar-launch = "bar_launch.__main__:main"
+
+[tool.setuptools]
+packages = ["bar_launch"]
+py-modules = ["slpp", "demoparser", "parse_demo_file", "BAR_Debug_Launcher"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,4 @@ bar-launch = "bar_launch.__main__:main"
 
 [tool.setuptools]
 packages = ["bar_launch"]
-py-modules = ["slpp", "demoparser", "parse_demo_file", "BAR_Debug_Launcher"]
+py-modules = ["slpp", "demoparser", "parse_demo_file", "script", "BAR_Debug_Launcher"]

--- a/tests/test_intents.py
+++ b/tests/test_intents.py
@@ -109,6 +109,36 @@ def test_pinned_no_match_raises():
         resolve_intent(Intent("bar", "pinned", "engine", version="9999.99"), FIXTURE_MODINFOS)
 
 
+def test_pinned_prefers_exact_token_over_substring():
+    # '2025.04.1' is a substring of '2025.04.10'; an exact token match must
+    # win even when the substring-only entry comes first in insertion order.
+    modinfos = {
+        "Beyond All Reason 2025.04.10 $VERSION": {"modtype": "1", "name": "Beyond All Reason 2025.04.10"},
+        "Beyond All Reason 2025.04.1 $VERSION": {"modtype": "1", "name": "Beyond All Reason 2025.04.1"},
+    }
+    label, mi = resolve_intent(Intent("bar", "pinned", "engine", version="2025.04.1"), modinfos)
+    assert label == "Beyond All Reason 2025.04.1 $VERSION"
+    # Partial pins still fall back to substring matching.
+    label, _ = resolve_intent(Intent("bar", "pinned", "engine", version="2025.04"), modinfos)
+    assert "2025.04" in label
+
+
+def test_local_matches_any_checkout_dir_name():
+    # The games/ scan labels checkouts '[LOCAL] {gamedir}' for any directory
+    # name; resolution must not depend on hardcoded checkout names.
+    modinfos = {
+        "[LOCAL] my-bar-fork.sdd": {"modtype": "1", "name": "My BAR Fork $VERSION"},
+        "[LOCAL] chobby-dev": {"modtype": "5", "name": "Chobby Dev $VERSION"},
+        "[LOCAL] Spring-launcher with chobby-dev": {"modtype": "0", "name": "Chobby Dev $VERSION"},
+    }
+    label, mi = resolve_intent(Intent("bar", "local", "engine"), modinfos)
+    assert label == "[LOCAL] my-bar-fork.sdd" and mi["modtype"] == "1"
+    label, mi = resolve_intent(Intent("chobby", "local", "engine"), modinfos)
+    assert label == "[LOCAL] chobby-dev" and mi["modtype"] == "5"
+    label, mi = resolve_intent(Intent("chobby", "local", "launcher"), modinfos)
+    assert label == "[LOCAL] Spring-launcher with chobby-dev" and mi["modtype"] == "0"
+
+
 # ---------------------------------------------------------------------------
 # Full permutation grid: 3 play x 3 source x 2 boot = 18 cells.
 #

--- a/tests/test_intents.py
+++ b/tests/test_intents.py
@@ -8,16 +8,27 @@ from __future__ import annotations
 
 import pytest
 
-from bar_launch.intents import Intent, default_boot, resolve_intent
+from bar_launch.intents import (
+    BOOT_CHOICES,
+    Intent,
+    PLAY_CHOICES,
+    SOURCE_CHOICES,
+    default_boot,
+    resolve_intent,
+)
 
 
 # Mirrors the canonical entries build_context() always inserts, plus a couple
 # of $VERSION-tagged + [LOCAL] entries to exercise pinned/local resolution.
+# Includes a chobby-pinned pair so the (chobby, pinned, *) cells of the matrix
+# can resolve to a real entry rather than KeyError on a missing fixture.
 FIXTURE_MODINFOS = {
     "Spring-launcher with rapid://byar-chobby:test": {"modtype": "0", "name": "rapid://byar-chobby:test"},
     "Latest BYAR Chobby Lobby: rapid://byar-chobby:test": {"name": "rapid://byar-chobby:test", "version": "", "modtype": "5"},
     "Latest BAR Game: rapid://byar:test": {"name": "rapid://byar:test", "version": "", "modtype": "1"},
     "Beyond All Reason 2025.04.1234 $VERSION": {"modtype": "1", "name": "Beyond All Reason 2025.04.1234"},
+    "Spring-launcher with BYAR Chobby v1.2.3 $VERSION": {"modtype": "0", "name": "BYAR Chobby v1.2.3"},
+    "BYAR Chobby v1.2.3 $VERSION (no launcher)": {"modtype": "5", "name": "BYAR Chobby v1.2.3"},
     "[LOCAL] Beyond-All-Reason": {"modtype": "1", "name": "Beyond All Reason $VERSION"},
     "[LOCAL] BYAR-Chobby": {"modtype": "5", "name": "BYAR Chobby $VERSION"},
     "[LOCAL] Spring-launcher with BYAR-Chobby": {"modtype": "0", "name": "BYAR Chobby $VERSION"},
@@ -89,10 +100,103 @@ def test_unknown_play_rejected():
 
 def test_local_bar_missing_raises():
     incomplete = {k: v for k, v in FIXTURE_MODINFOS.items() if not k.startswith("[LOCAL] Beyond")}
-    with pytest.raises(KeyError, match="link::create"):
+    with pytest.raises(KeyError, match="linked into"):
         resolve_intent(Intent("bar", "local", "engine"), incomplete)
 
 
 def test_pinned_no_match_raises():
     with pytest.raises(KeyError, match="no entry containing"):
         resolve_intent(Intent("bar", "pinned", "engine", version="9999.99"), FIXTURE_MODINFOS)
+
+
+# ---------------------------------------------------------------------------
+# Full permutation grid: 3 play x 3 source x 2 boot = 18 cells.
+#
+# Each cell is one of:
+#   ("ok", expected_label, expected_modtype)  -- resolves cleanly
+#   ("raise", exc_type, message_substring)    -- resolve_intent rejects it
+#
+# The matrix is the canonical reference for what every (play, source, boot)
+# combination is *supposed* to do. If you change resolve_intent's behaviour,
+# update the matrix in the same diff so the regression net stays explicit.
+#
+# Notes on edge cells:
+#   - (replay, *, *) all reject: replay goes through try_start_replay, which
+#     handles its own engine resolution from the demo header.
+#   - (bar, latest, launcher) and (bar, latest, engine) resolve to the *same*
+#     label ("Latest BAR Game: rapid://byar:test", modtype=1). resolve_intent
+#     intentionally ignores boot for play=bar+source=latest because there is
+#     only one canonical "latest BAR" entry. The boot axis only diverges for
+#     chobby (where rapid:// vs direct-engine are two real labels) and for
+#     pinned cached versions (where the modtype differs).
+#   - (bar, local, launcher) silently degrades to engine boot: there is no
+#     "[LOCAL] Spring-launcher with Beyond-All-Reason" entry — local BAR
+#     checkouts only exist as modtype=1, and intents.py picks the modtype=1
+#     entry rather than raising. If we want this to raise instead, change
+#     intents.py and flip this cell from "ok" to "raise".
+# ---------------------------------------------------------------------------
+
+# version is supplied for all (*, pinned, *) cells; resolve_intent rejects
+# pinned without version separately in test_pinned_requires_version above.
+_MATRIX = {
+    # (chobby, latest, *)
+    ("chobby", "latest", "launcher"): ("ok", "Spring-launcher with rapid://byar-chobby:test", "0"),
+    ("chobby", "latest", "engine"):   ("ok", "Latest BYAR Chobby Lobby: rapid://byar-chobby:test", "5"),
+    # (bar, latest, *) -- boot axis collapses for latest BAR
+    ("bar", "latest", "launcher"):    ("ok", "Latest BAR Game: rapid://byar:test", "1"),
+    ("bar", "latest", "engine"):      ("ok", "Latest BAR Game: rapid://byar:test", "1"),
+    # (chobby, local, *)
+    ("chobby", "local", "launcher"):  ("ok", "[LOCAL] Spring-launcher with BYAR-Chobby", "0"),
+    ("chobby", "local", "engine"):    ("ok", "[LOCAL] BYAR-Chobby", "5"),
+    # (bar, local, *) -- launcher silently degrades to the modtype=1 entry
+    ("bar", "local", "launcher"):     ("ok", "[LOCAL] Beyond-All-Reason", "1"),
+    ("bar", "local", "engine"):       ("ok", "[LOCAL] Beyond-All-Reason", "1"),
+    # (chobby, pinned, *) -- needs a version that substring-matches a fixture entry
+    ("chobby", "pinned", "launcher"): ("ok", "Spring-launcher with BYAR Chobby v1.2.3 $VERSION", "0"),
+    ("chobby", "pinned", "engine"):   ("ok", "BYAR Chobby v1.2.3 $VERSION (no launcher)", "5"),
+    # (bar, pinned, *)
+    ("bar", "pinned", "launcher"):    ("ok", "Beyond All Reason 2025.04.1234 $VERSION", "1"),
+    ("bar", "pinned", "engine"):      ("ok", "Beyond All Reason 2025.04.1234 $VERSION", "1"),
+    # (replay, *, *) -- always rejected
+    ("replay", "latest", "launcher"): ("raise", ValueError, "try_start_replay"),
+    ("replay", "latest", "engine"):   ("raise", ValueError, "try_start_replay"),
+    ("replay", "local", "launcher"):  ("raise", ValueError, "try_start_replay"),
+    ("replay", "local", "engine"):    ("raise", ValueError, "try_start_replay"),
+    ("replay", "pinned", "launcher"): ("raise", ValueError, "try_start_replay"),
+    ("replay", "pinned", "engine"):   ("raise", ValueError, "try_start_replay"),
+}
+
+
+# Sanity check: the matrix MUST cover every cell. If someone adds a new
+# play/source/boot value, this catches the missing rows immediately.
+def test_matrix_is_complete():
+    expected = {(p, s, b) for p in PLAY_CHOICES for s in SOURCE_CHOICES for b in BOOT_CHOICES}
+    assert set(_MATRIX.keys()) == expected, (
+        f"matrix missing: {expected - set(_MATRIX.keys())}; "
+        f"extra: {set(_MATRIX.keys()) - expected}"
+    )
+
+
+# Version supplied for (*, pinned, *) cells. "replay" never reaches the
+# version-substring lookup -- resolve_intent rejects it on play before then --
+# but we still need *some* string so the version-required check earlier in
+# resolve_intent doesn't fire first and shadow the expected error message.
+_PINNED_VERSION = {"chobby": "v1.2.3", "bar": "2025.04", "replay": "irrelevant"}
+
+
+@pytest.mark.parametrize(("play", "source", "boot"), sorted(_MATRIX.keys()))
+def test_intent_grid(play, source, boot):
+    expectation = _MATRIX[(play, source, boot)]
+    version = _PINNED_VERSION.get(play) if source == "pinned" else None
+    intent = Intent(play, source, boot, version=version)
+
+    if expectation[0] == "raise":
+        _, exc_type, msg_substr = expectation
+        with pytest.raises(exc_type, match=msg_substr):
+            resolve_intent(intent, FIXTURE_MODINFOS)
+        return
+
+    _, expected_label, expected_modtype = expectation
+    label, mi = resolve_intent(intent, FIXTURE_MODINFOS)
+    assert label == expected_label, (play, source, boot)
+    assert str(mi["modtype"]) == expected_modtype, (play, source, boot)

--- a/tests/test_intents.py
+++ b/tests/test_intents.py
@@ -1,0 +1,98 @@
+"""Unit tests for bar_launch.intents.
+
+These run without Tk and without a populated BAR data dir — they exercise the
+intent translation against a fixture modinfos dict that mirrors what
+build_context() produces in practice.
+"""
+from __future__ import annotations
+
+import pytest
+
+from bar_launch.intents import Intent, default_boot, resolve_intent
+
+
+# Mirrors the canonical entries build_context() always inserts, plus a couple
+# of $VERSION-tagged + [LOCAL] entries to exercise pinned/local resolution.
+FIXTURE_MODINFOS = {
+    "Spring-launcher with rapid://byar-chobby:test": {"modtype": "0", "name": "rapid://byar-chobby:test"},
+    "Latest BYAR Chobby Lobby: rapid://byar-chobby:test": {"name": "rapid://byar-chobby:test", "version": "", "modtype": "5"},
+    "Latest BAR Game: rapid://byar:test": {"name": "rapid://byar:test", "version": "", "modtype": "1"},
+    "Beyond All Reason 2025.04.1234 $VERSION": {"modtype": "1", "name": "Beyond All Reason 2025.04.1234"},
+    "[LOCAL] Beyond-All-Reason": {"modtype": "1", "name": "Beyond All Reason $VERSION"},
+    "[LOCAL] BYAR-Chobby": {"modtype": "5", "name": "BYAR Chobby $VERSION"},
+    "[LOCAL] Spring-launcher with BYAR-Chobby": {"modtype": "0", "name": "BYAR Chobby $VERSION"},
+}
+
+
+def test_default_boot():
+    assert default_boot("chobby") == "launcher"
+    assert default_boot("bar") == "engine"
+    assert default_boot("replay") == "engine"
+
+
+def test_latest_chobby_via_launcher():
+    label, mi = resolve_intent(Intent("chobby", "latest", "launcher"), FIXTURE_MODINFOS)
+    assert label == "Spring-launcher with rapid://byar-chobby:test"
+    assert mi["modtype"] == "0"
+
+
+def test_latest_chobby_direct_engine():
+    label, mi = resolve_intent(Intent("chobby", "latest", "engine"), FIXTURE_MODINFOS)
+    assert label == "Latest BYAR Chobby Lobby: rapid://byar-chobby:test"
+    assert mi["modtype"] == "5"
+
+
+def test_latest_bar_engine():
+    label, mi = resolve_intent(Intent("bar", "latest", "engine"), FIXTURE_MODINFOS)
+    assert label == "Latest BAR Game: rapid://byar:test"
+    assert mi["modtype"] == "1"
+
+
+def test_local_bar_engine():
+    label, mi = resolve_intent(Intent("bar", "local", "engine"), FIXTURE_MODINFOS)
+    assert label == "[LOCAL] Beyond-All-Reason"
+    assert mi["modtype"] == "1"
+
+
+def test_local_chobby_launcher():
+    label, mi = resolve_intent(Intent("chobby", "local", "launcher"), FIXTURE_MODINFOS)
+    assert label == "[LOCAL] Spring-launcher with BYAR-Chobby"
+    assert mi["modtype"] == "0"
+
+
+def test_local_chobby_engine():
+    label, mi = resolve_intent(Intent("chobby", "local", "engine"), FIXTURE_MODINFOS)
+    assert label == "[LOCAL] BYAR-Chobby"
+    assert mi["modtype"] == "5"
+
+
+def test_pinned_bar_by_substring():
+    label, mi = resolve_intent(Intent("bar", "pinned", "engine", version="2025.04"), FIXTURE_MODINFOS)
+    assert "2025.04.1234" in label
+    assert mi["modtype"] == "1"
+
+
+def test_pinned_requires_version():
+    with pytest.raises(ValueError, match="requires version"):
+        resolve_intent(Intent("bar", "pinned", "engine"), FIXTURE_MODINFOS)
+
+
+def test_replay_intent_rejected():
+    with pytest.raises(ValueError, match="try_start_replay"):
+        resolve_intent(Intent("replay", "latest", "engine"), FIXTURE_MODINFOS)
+
+
+def test_unknown_play_rejected():
+    with pytest.raises(ValueError, match="unknown play"):
+        resolve_intent(Intent("blizzcon", "latest", "engine"), FIXTURE_MODINFOS)
+
+
+def test_local_bar_missing_raises():
+    incomplete = {k: v for k, v in FIXTURE_MODINFOS.items() if not k.startswith("[LOCAL] Beyond")}
+    with pytest.raises(KeyError, match="link::create"):
+        resolve_intent(Intent("bar", "local", "engine"), incomplete)
+
+
+def test_pinned_no_match_raises():
+    with pytest.raises(KeyError, match="no entry containing"):
+        resolve_intent(Intent("bar", "pinned", "engine", version="9999.99"), FIXTURE_MODINFOS)

--- a/tests/test_print_cmd.py
+++ b/tests/test_print_cmd.py
@@ -1,0 +1,117 @@
+"""End-to-end smoke test for `python -m bar_launch --print-cmd ...`.
+
+Exercises the same (play, source, boot) matrix as test_intents.py, but drives
+the full main() entry point against a fixture Context (no Tk, no real BAR
+data dir, no subprocess). Confirms that resolve_intent + build_runcmd compose
+correctly: every valid intent in the grid produces a non-empty engine command
+string with the expected boot-mode shape.
+
+If something breaks the GUI's gencmd path -- which calls the same resolve_intent
++ build_runcmd pair -- this catches it without needing a live Tk session.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+import bar_launch.__main__ as bl_main
+from bar_launch.core import Context
+
+from tests.test_intents import FIXTURE_MODINFOS, _MATRIX, _PINNED_VERSION
+
+
+@pytest.fixture
+def fake_ctx(tmp_path):
+    # build_runcmd writes side-effect files (start script / dev-lobby config)
+    # into cwd; chdir into tmp_path so we don't pollute the repo.
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        engine_key = "recoil_2025.06.19"
+        ctx = Context(
+            barinstallpath=str(tmp_path),
+            datafolder="data",
+            launcher_binary="Beyond-All-Reason.AppImage",
+            engines={engine_key: str(tmp_path / "data" / "engine" / engine_key / "spring")},
+            modinfos=dict(FIXTURE_MODINFOS),
+        )
+        yield ctx, engine_key
+    finally:
+        os.chdir(old_cwd)
+
+
+@contextmanager
+def _patched_main(ctx):
+    # main() calls build_context() to build a real Context. We swap it for a
+    # function that returns the fixture Context regardless of args.
+    with patch.object(bl_main, "build_context", lambda **kw: ctx):
+        yield
+
+
+_VALID_CELLS = sorted(
+    (p, s, b) for (p, s, b), v in _MATRIX.items() if v[0] == "ok"
+)
+_INVALID_CELLS = sorted(
+    (p, s, b) for (p, s, b), v in _MATRIX.items() if v[0] == "raise"
+)
+
+
+@pytest.mark.parametrize(("play", "source", "boot"), _VALID_CELLS)
+def test_print_cmd_grid_valid(fake_ctx, capsys, play, source, boot):
+    ctx, engine_key = fake_ctx
+    argv = ["--print-cmd", "--play", play, "--source", source, "--boot", boot,
+            "--engine", engine_key]
+    if source == "pinned":
+        argv += ["--version", _PINNED_VERSION[play]]
+
+    with _patched_main(ctx):
+        rc = bl_main.main(argv)
+    assert rc == 0, (play, source, boot)
+
+    out = capsys.readouterr().out.strip().splitlines()[-1]
+    # Resolve what the matrix says we should land on, then check the printed
+    # command's *shape* matches that modtype.
+    expected_label = _MATRIX[(play, source, boot)][1]
+    expected_modtype = _MATRIX[(play, source, boot)][2]
+    if expected_modtype == "0":
+        # AppImage launcher path: "<install>/<launcher>" -c "<config.json>"
+        assert "Beyond-All-Reason.AppImage" in out, (play, source, boot, out)
+        assert "bar_debug_launcher_config.json" in out, (play, source, boot, out)
+    elif expected_modtype == "5":
+        # Engine direct, --menu mode.
+        assert "--menu" in out, (play, source, boot, out)
+        assert "Beyond-All-Reason.AppImage" not in out, (play, source, boot, out)
+    elif expected_modtype == "1":
+        # Engine direct, no map = bare invocation; no --menu, no -c.
+        assert "--isolation" in out, (play, source, boot, out)
+        assert "--menu" not in out, (play, source, boot, out)
+        assert "-c " not in out, (play, source, boot, out)
+
+
+@pytest.mark.parametrize(("play", "source", "boot"), _INVALID_CELLS)
+def test_print_cmd_grid_invalid(fake_ctx, play, source, boot):
+    ctx, engine_key = fake_ctx
+    argv = ["--print-cmd", "--play", play, "--source", source, "--boot", boot,
+            "--engine", engine_key]
+    if source == "pinned":
+        argv += ["--version", _PINNED_VERSION[play]]
+
+    with _patched_main(ctx):
+        # Replay cells raise ValueError out of resolve_intent. main() doesn't
+        # catch it -- which is fine: the CLI surfaces the error to stderr and
+        # exits non-zero. We just assert it bubbled up.
+        with pytest.raises(ValueError, match="try_start_replay"):
+            bl_main.main(argv)
+
+
+def test_print_cmd_pinned_requires_version(fake_ctx):
+    ctx, engine_key = fake_ctx
+    argv = ["--print-cmd", "--play", "bar", "--source", "pinned", "--boot", "engine",
+            "--engine", engine_key]
+    with _patched_main(ctx):
+        with pytest.raises(ValueError, match="requires version"):
+            bl_main.main(argv)


### PR DESCRIPTION
## What's it do
Supports `just bar::launch` over in BAR-Devtools.

The single mega-dropdown of cryptic labels is gone. Three orthogonal source axes -- Engine, Chobby, Game each get their own dropdown. Whichever is active depends on Play; the inactive ones grey out but keep their value, so toggling Play between chobby and BAR doesn't blow away your other-axis pin.

Every per-field detail lives in a hover tooltip (current vs. inactive state, resolved modinfo label, archive name, modtype, on-disk checkout path for local sources) -- the Details... popup is gone. Visual overhaul to a clam ttk theme + LabelFrames; the inlined GitHub URL becomes a clickable link.

Other changes:
- BAR_APPIMAGE_PATH now accepts a directory, not just a file. Point it at ~/apps/BAR/ and the launcher scans for the AppImage instead of needing the exact filename in .env.
- --no-gui gains --headless as an alias. Intent flags (--play etc.)  no longer trip the launcher into headless mode on their own; GUI is the default and going headless is an explicit choice.
- Window sizing is content-driven with MIN_W/MIN_H floors; an after_idle resize defeats Tk's auto-fit-to-content shrink.

Tests: tests/test_intents.py expanded to the full 18-cell (play x source x boot) matrix with a complete-coverage assertion. New tests/test_print_cmd.py drives main(['--print-cmd', ...]) over the same matrix against a fixture Context, exercising resolve_intent and build_runcmd end-to-end without Tk. 51 tests total.

## Screenshots
<img width="884" height="865" alt="image" src="https://github.com/user-attachments/assets/edd80db1-dbba-4ad9-90a1-870678d5166e" />
<img width="772" height="253" alt="image" src="https://github.com/user-attachments/assets/a5d35258-3149-4fed-8086-c679461e39e7" />

## LLMs
yes, Opus 4.6 for this one. Planned it out extensively and have reviewed it extensively at this point.